### PR TITLE
Improved cookies

### DIFF
--- a/macaroonbakery/httpbakery/client.py
+++ b/macaroonbakery/httpbakery/client.py
@@ -118,16 +118,18 @@ def _prepare_discharge_hook(req, key, jar, visit_page):
             name = 'macaroon-' + info['CookieNameSuffix']
         else:
             name = 'macaroon-' + discharges[0].signature
+        domain = parsed_url.hostname or parsed_url.netloc
+        port = str(parsed_url.port) if parsed_url.port is not None else None
         cookie = Cookie(
             version=0,
             name=name,
             value=all_macaroons,
-            port=None,
-            port_specified=False,
-            domain=parsed_url[1],
+            port=port,
+            port_specified=port is not None,
+            domain=domain,
             domain_specified=True,
             domain_initial_dot=False,
-            path=parsed_url[2],
+            path=parsed_url.path,
             path_specified=True,
             secure=False,
             expires=None,

--- a/macaroonbakery/httpbakery/client.py
+++ b/macaroonbakery/httpbakery/client.py
@@ -120,6 +120,7 @@ def _prepare_discharge_hook(req, key, jar, visit_page):
             name = 'macaroon-' + discharges[0].signature
         domain = parsed_url.hostname or parsed_url.netloc
         port = str(parsed_url.port) if parsed_url.port is not None else None
+        secure = parsed_url.scheme == 'https'
         cookie = Cookie(
             version=0,
             name=name,
@@ -131,7 +132,7 @@ def _prepare_discharge_hook(req, key, jar, visit_page):
             domain_initial_dot=False,
             path=parsed_url.path,
             path_specified=True,
-            secure=False,
+            secure=secure,
             expires=None,
             discard=False,
             comment=None,


### PR DESCRIPTION
Improve cookie handling for macaroons by:

1. support cookies for urls containing a port number (eg, example.com:8000)
2. support secure cookies for https urls