### PR TITLE
cosmetic changes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ project_root = os.path.dirname(cwd)
 # version is used.
 sys.path.insert(0, project_root)
 
-import macaroonbakery
+import macaroonbakery as bakery
 
 # -- General configuration ---------------------------------------------
 

--- a/macaroonbakery/__init__.py
+++ b/macaroonbakery/__init__.py
@@ -1,59 +1,92 @@
 # Copyright 2017 Canonical Ltd.
 # Licensed under the LGPLv3, see LICENCE file for details.
 
-from __future__ import unicode_literals
-try:
-    import urllib3.contrib.pyopenssl
-except ImportError:
-    pass
-else:
-    urllib3.contrib.pyopenssl.inject_into_urllib3()
-
 from macaroonbakery.versions import (
-    LATEST_BAKERY_VERSION, BAKERY_V3, BAKERY_V2, BAKERY_V1, BAKERY_V0
+    BAKERY_V0,
+    BAKERY_V1,
+    BAKERY_V2,
+    BAKERY_V3,
+    LATEST_BAKERY_VERSION,
 )
 from macaroonbakery.authorizer import (
-    ClosedAuthorizer, EVERYONE, AuthorizerFunc, Authorizer, ACLAuthorizer
+    ACLAuthorizer,
+    Authorizer,
+    AuthorizerFunc,
+    ClosedAuthorizer,
+    EVERYONE,
 )
 from macaroonbakery.codec import (
-    encode_caveat, decode_caveat, encode_uvarint
+    decode_caveat,
+    encode_caveat,
+    encode_uvarint,
 )
 from macaroonbakery.checker import (
-    Op, LOGIN_OP, AuthInfo, AuthChecker, Checker
+    AuthChecker,
+    AuthInfo,
+    Checker,
+    LOGIN_OP,
+    Op,
 )
 from macaroonbakery.error import (
-    ThirdPartyCaveatCheckFailed, CaveatNotRecognizedError, AuthInitError,
-    PermissionDenied, IdentityError, DischargeRequiredError, VerificationError,
-    ThirdPartyInfoNotFound
+    AuthInitError,
+    CaveatNotRecognizedError,
+    DischargeRequiredError,
+    IdentityError,
+    PermissionDenied,
+    ThirdPartyCaveatCheckFailed,
+    ThirdPartyInfoNotFound,
+    VerificationError,
 )
 from macaroonbakery.identity import (
-    Identity, ACLIdentity, SimpleIdentity, IdentityClient, NoIdentities
+    ACLIdentity,
+    Identity,
+    IdentityClient,
+    NoIdentities,
+    SimpleIdentity,
 )
-from macaroonbakery.keys import generate_key, PrivateKey, PublicKey
-from macaroonbakery.store import MemoryOpsStore, MemoryKeyStore
+from macaroonbakery.keys import (
+    generate_key,
+    PrivateKey,
+    PublicKey,
+)
+from macaroonbakery.store import (
+    MemoryOpsStore,
+    MemoryKeyStore,
+)
 from macaroonbakery.third_party import (
-    ThirdPartyCaveatInfo, ThirdPartyInfo, legacy_namespace
+    ThirdPartyCaveatInfo,
+    ThirdPartyInfo,
+    legacy_namespace,
 )
 from macaroonbakery.macaroon import (
-    Macaroon, MacaroonJSONDecoder, MacaroonJSONEncoder, ThirdPartyStore,
-    ThirdPartyLocator, macaroon_version
+    Macaroon,
+    MacaroonJSONDecoder,
+    MacaroonJSONEncoder,
+    ThirdPartyLocator,
+    ThirdPartyStore,
+    macaroon_version,
 )
 from macaroonbakery.discharge import (
-    discharge_all, discharge, local_third_party_caveat, ThirdPartyCaveatChecker
+    ThirdPartyCaveatChecker,
+    discharge,
+    discharge_all,
+    local_third_party_caveat,
 )
-from macaroonbakery.oven import Oven, canonical_ops
+from macaroonbakery.oven import (
+    Oven,
+    canonical_ops,
+)
 from macaroonbakery.bakery import Bakery
-
+from macaroonbakery.utils import b64decode
 
 __all__ = [
-    'ACLIdentity',
     'ACLAuthorizer',
+    'ACLIdentity',
     'AuthChecker',
     'AuthInfo',
     'AuthInitError',
     'Authorizer',
     'AuthorizerFunc',
-    'Bakery',
     'BAKERY_V0',
     'BAKERY_V1',
     'BAKERY_V2',
@@ -80,7 +113,6 @@ __all__ = [
     'PermissionDenied',
     'PrivateKey',
     'PublicKey',
-    'NoIdentities',
     'SimpleIdentity',
     'ThirdPartyCaveatCheckFailed',
     'ThirdPartyCaveatChecker',
@@ -91,6 +123,7 @@ __all__ = [
     'ThirdPartyStore',
     'VERSION',
     'VerificationError',
+    'b64decode',
     'canonical_ops',
     'decode_caveat',
     'discharge',

--- a/macaroonbakery/authorizer.py
+++ b/macaroonbakery/authorizer.py
@@ -2,7 +2,7 @@
 # Licensed under the LGPLv3, see LICENCE file for details.
 import abc
 
-import macaroonbakery
+import macaroonbakery as bakery
 
 
 # EVERYONE is recognized by ACLAuthorizer as the name of a
@@ -90,7 +90,7 @@ class ACLAuthorizer(Authorizer):
             # Anyone is allowed to do nothing.
             return [], []
         allowed = [False] * len(ops)
-        has_allow = isinstance(identity, macaroonbakery.ACLIdentity)
+        has_allow = isinstance(identity, bakery.ACLIdentity)
         for i, op in enumerate(ops):
             acl = self._get_acl(ctx, op)
             if has_allow:

--- a/macaroonbakery/checker.py
+++ b/macaroonbakery/checker.py
@@ -6,7 +6,7 @@ from threading import Lock
 
 import pyrfc3339
 
-import macaroonbakery
+import macaroonbakery as bakery
 import macaroonbakery.checkers as checkers
 
 
@@ -38,7 +38,7 @@ class Checker(object):
     See the Oven type (TODO) for one way of doing that.
     '''
     def __init__(self, checker=checkers.Checker(),
-                 authorizer=macaroonbakery.ClosedAuthorizer(),
+                 authorizer=bakery.ClosedAuthorizer(),
                  identity_client=None,
                  macaroon_opstore=None):
         '''
@@ -57,7 +57,7 @@ class Checker(object):
         self._first_party_caveat_checker = checker
         self._authorizer = authorizer
         if identity_client is None:
-            identity_client = macaroonbakery.NoIdentities()
+            identity_client = bakery.NoIdentities()
         self._identity_client = identity_client
         self._macaroon_opstore = macaroon_opstore
 
@@ -106,7 +106,7 @@ class AuthChecker(object):
                 self._init_once(ctx)
                 self._executed = True
         if self._init_errors is not None and len(self._init_errors) > 0:
-            raise macaroonbakery.AuthInitError(self._init_errors[0])
+            raise bakery.AuthInitError(self._init_errors[0])
 
     def _init_once(self, ctx):
         self._auth_indexes = {}
@@ -115,7 +115,7 @@ class AuthChecker(object):
             try:
                 ops, conditions = self.parent._macaroon_opstore.macaroon_ops(
                     ms)
-            except macaroonbakery.VerificationError:
+            except bakery.VerificationError:
                 raise
             except Exception as exc:
                 self._init_errors.append(exc.args[0])
@@ -157,7 +157,7 @@ class AuthChecker(object):
             try:
                 identity = self.parent._identity_client.declared_identity(
                     ctx, declared)
-            except macaroonbakery.IdentityError as exc:
+            except bakery.IdentityError as exc:
                 self._init_errors.append(
                     'cannot decode declared identity: {}'.format(exc.args[0]))
                 continue
@@ -171,7 +171,7 @@ class AuthChecker(object):
             try:
                 identity, cavs = self.parent.\
                     _identity_client.identity_from_context(ctx)
-            except macaroonbakery.IdentityError:
+            except bakery.IdentityError:
                 self._init_errors.append('could not determine identity')
             if cavs is None:
                 cavs = []
@@ -292,7 +292,7 @@ class AuthChecker(object):
             # no caveats to be discharged.
             return authed, used
         if self._identity is None and len(self._identity_caveats) > 0:
-            raise macaroonbakery.DischargeRequiredError(
+            raise bakery.DischargeRequiredError(
                 msg='authentication required',
                 ops=[LOGIN_OP],
                 cavs=self._identity_caveats)
@@ -303,8 +303,8 @@ class AuthChecker(object):
             err = ''
             if len(all_errors) > 0:
                 err = all_errors[0]
-            raise macaroonbakery.PermissionDenied(err)
-        raise macaroonbakery.DischargeRequiredError(
+            raise bakery.PermissionDenied(err)
+        raise bakery.DischargeRequiredError(
             msg='some operations have extra caveats', ops=ops, cavs=caveats)
 
     def allow_capability(self, ctx, ops):

--- a/macaroonbakery/checkers/time.py
+++ b/macaroonbakery/checkers/time.py
@@ -35,7 +35,7 @@ def macaroons_expiry_time(ns, ms):
     for m in ms:
         et = expiry_time(ns, m.caveats)
         if et is not None and (t is None or et < t):
-                t = et
+            t = et
     return t
 
 

--- a/macaroonbakery/httpbakery/agent/agent.py
+++ b/macaroonbakery/httpbakery/agent/agent.py
@@ -11,7 +11,7 @@ import six
 from six.moves.urllib.parse import urlparse
 from six.moves.urllib.parse import urljoin
 
-import macaroonbakery
+import macaroonbakery as bakery
 import macaroonbakery.utils as utils
 import macaroonbakery.httpbakery as httpbakery
 
@@ -118,8 +118,8 @@ class AgentInteractor(httpbakery.Interactor, httpbakery.LegacyInteractor):
         m = resp.json().get('macaroon')
         if m is None:
             raise httpbakery.InteractionError('no macaroon in response')
-        m = macaroonbakery.Macaroon.from_dict(m)
-        ms = macaroonbakery.discharge_all(m, None, self._auth_info.key)
+        m = bakery.Macaroon.from_dict(m)
+        ms = bakery.discharge_all(m, None, self._auth_info.key)
         b = bytearray()
         for m in ms:
             b.extend(utils.b64decode(m.serialize()))

--- a/macaroonbakery/httpbakery/client.py
+++ b/macaroonbakery/httpbakery/client.py
@@ -41,7 +41,7 @@ class Client:
     should be passed to requests as is used to initialize
     the client.
     For example:
-        import bakery.httpbakery
+        import macaroonbakery.httpbakery
         client = httpbakery.Client()
         resp = requests.get('some protected url',
                             cookies=client.cookies,
@@ -84,7 +84,7 @@ class Client:
         as an HTTP URL.
         @param cav Third party {pymacaroons.Caveat} to be discharged.
         @param payload External caveat data {bytes}.
-        @return The acquired macaroon {bakery.Macaroon}
+        @return The acquired macaroon {macaroonbakery.Macaroon}
         '''
         resp = self._acquire_discharge_with_token(cav, payload, None)
         # TODO Fabrice what is the other http response possible ??
@@ -197,7 +197,7 @@ class _BakeryAuth:
     def __init__(self, client):
         '''
         @param interaction_methods A list of Interactor implementations.
-        @param key The private key of the client (bakery.PrivateKey)
+        @param key The private key of the client (macaroonbakery.PrivateKey)
         @param cookies storage for the cookies {CookieJar}. It should be the
         same as in the requests cookies.
         '''

--- a/macaroonbakery/httpbakery/discharge.py
+++ b/macaroonbakery/httpbakery/discharge.py
@@ -10,8 +10,8 @@ def discharge(ctx, content, key, locator, checker):
     @param ctx The context passed to the checker {checkers.AuthContext}
     @param content URL and form parameters {dict}
     @param locator Locator used to add third party caveats returned by
-    the checker {bakery.ThirdPartyLocator}
-    @param checker Used to check third party caveats {bakery.ThirdPartyCaveatChecker}
+    the checker {macaroonbakery.ThirdPartyLocator}
+    @param checker Used to check third party caveats {macaroonbakery.ThirdPartyCaveatChecker}
     @return The discharge macaroon {macaroonbakery.Macaroon}
     '''
     id = content.get('id')

--- a/macaroonbakery/httpbakery/error.py
+++ b/macaroonbakery/httpbakery/error.py
@@ -3,8 +3,7 @@
 from collections import namedtuple
 import json
 
-from macaroonbakery import BAKERY_V1, LATEST_BAKERY_VERSION
-from macaroonbakery import Macaroon
+import macaroonbakery as bakery
 
 ERR_INTERACTION_REQUIRED = 'interaction required'
 ERR_DISCHARGE_REQUIRED = 'macaroon discharge required'
@@ -83,16 +82,16 @@ def request_version(req_headers):
     vs = req_headers.get(BAKERY_PROTOCOL_HEADER)
     if vs is None:
         # No header - use backward compatibility mode.
-        return BAKERY_V1
+        return bakery.BAKERY_V1
     try:
         x = int(vs)
     except ValueError:
         # Badly formed header - use backward compatibility mode.
-        return BAKERY_V1
-    if x > LATEST_BAKERY_VERSION:
+        return bakery.BAKERY_V1
+    if x > bakery.LATEST_BAKERY_VERSION:
         # Later version than we know about - use the
         # latest version that we can.
-        return LATEST_BAKERY_VERSION
+        return bakery.LATEST_BAKERY_VERSION
     return x
 
 
@@ -109,7 +108,7 @@ class Error(namedtuple('Error', 'code, message, version, info')):
         message = serialized.get('Message')
         info = ErrorInfo.from_dict(serialized.get('Info'))
         return Error(code=code, message=message, info=info,
-                     version=LATEST_BAKERY_VERSION)
+                     version=bakery.LATEST_BAKERY_VERSION)
 
     def interaction_method(self, kind, x):
         ''' Checks whether the error is an InteractionRequired error
@@ -179,7 +178,7 @@ class ErrorInfo(
             return None
         macaroon = serialized.get('Macaroon')
         if macaroon is not None:
-            macaroon = Macaroon.deserialize_json(macaroon)
+            macaroon = bakery.Macaroon.deserialize_json(macaroon)
         path = serialized.get('MacaroonPath')
         cookie_name_suffix = serialized.get('CookieNameSuffix')
         visit_url = serialized.get('VisitURL')

--- a/macaroonbakery/identity.py
+++ b/macaroonbakery/identity.py
@@ -2,7 +2,7 @@
 # Licensed under the LGPLv3, see LICENCE file for details.
 import abc
 
-import macaroonbakery
+import macaroonbakery as bakery
 
 
 class Identity(object):
@@ -123,4 +123,4 @@ class NoIdentities(IdentityClient):
         return None, None
 
     def declared_identity(self, ctx, declared):
-        raise macaroonbakery.IdentityError('no identity declared or possible')
+        raise bakery.IdentityError('no identity declared or possible')

--- a/macaroonbakery/tests/common.py
+++ b/macaroonbakery/tests/common.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 import pytz
 
-import macaroonbakery
+import macaroonbakery as bakery
 import macaroonbakery.checkers as checkers
 
 
@@ -51,7 +51,7 @@ def true_check(ctx, cond, args):
     return None
 
 
-class OneIdentity(macaroonbakery.IdentityClient):
+class OneIdentity(bakery.IdentityClient):
     '''An IdentityClient implementation that always returns a single identity
     from declared_identity, allowing allow(LOGIN_OP) to work even when there
     are no declaration caveats (this is mostly to support the legacy tests
@@ -73,7 +73,7 @@ class _NoOne(object):
         return ''
 
 
-class ThirdPartyStrcmpChecker(macaroonbakery.ThirdPartyCaveatChecker):
+class ThirdPartyStrcmpChecker(bakery.ThirdPartyCaveatChecker):
     def __init__(self, str):
         self.str = str
 
@@ -82,12 +82,12 @@ class ThirdPartyStrcmpChecker(macaroonbakery.ThirdPartyCaveatChecker):
         if isinstance(cav_info.condition, bytes):
             condition = cav_info.condition.decode('utf-8')
         if condition != self.str:
-            raise macaroonbakery.ThirdPartyCaveatCheckFailed(
+            raise bakery.ThirdPartyCaveatCheckFailed(
                 '{} doesn\'t match {}'.format(condition, self.str))
         return []
 
 
-class ThirdPartyCheckerWithCaveats(macaroonbakery.ThirdPartyCaveatChecker):
+class ThirdPartyCheckerWithCaveats(bakery.ThirdPartyCaveatChecker):
     def __init__(self, cavs=None):
         if cavs is None:
             cavs = []
@@ -97,7 +97,7 @@ class ThirdPartyCheckerWithCaveats(macaroonbakery.ThirdPartyCaveatChecker):
         return self.cavs
 
 
-class ThirdPartyCaveatCheckerEmpty(macaroonbakery.ThirdPartyCaveatChecker):
+class ThirdPartyCaveatCheckerEmpty(bakery.ThirdPartyCaveatChecker):
     def check_third_party_caveat(self, ctx, cav_info):
         return []
 
@@ -107,14 +107,16 @@ def new_bakery(location, locator=None):
     # key pair, and registers the key with the given locator if provided.
     #
     # It uses test_checker to check first party caveats.
-    key = macaroonbakery.generate_key()
+    key = bakery.generate_key()
     if locator is not None:
         locator.add_info(location,
-                         macaroonbakery.ThirdPartyInfo(
+                         bakery.ThirdPartyInfo(
                              public_key=key.public_key,
-                             version=macaroonbakery.LATEST_BAKERY_VERSION))
-    return macaroonbakery.Bakery(key=key,
-                                 checker=test_checker(),
-                                 location=location,
-                                 identity_client=OneIdentity(),
-                                 locator=locator)
+                             version=bakery.LATEST_BAKERY_VERSION))
+    return bakery.Bakery(
+        key=key,
+        checker=test_checker(),
+        location=location,
+        identity_client=OneIdentity(),
+        locator=locator,
+    )

--- a/macaroonbakery/tests/test_checker.py
+++ b/macaroonbakery/tests/test_checker.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 from pymacaroons.verifier import Verifier, FirstPartyCaveatVerifierDelegate
 import pymacaroons
 
-import macaroonbakery
+import macaroonbakery as bakery
 import macaroonbakery.checkers as checkers
 from macaroonbakery.tests.common import test_context, epoch, test_checker
 
@@ -22,13 +22,13 @@ class TestChecker(TestCase):
         locator = _DischargerLocator()
         ids = _IdService('ids', locator, self)
         auth = _OpAuthorizer(
-            {macaroonbakery.Op(entity='something', action='read'):
-                {macaroonbakery.EVERYONE}})
+            {bakery.Op(entity='something', action='read'):
+                {bakery.EVERYONE}})
         ts = _Service('myservice', auth, ids, locator)
         client = _Client(locator)
-        auth_info = client.do(test_context, ts,
-                              [macaroonbakery.Op(entity='something',
-                                                 action='read')])
+        auth_info = client.do(test_context, ts, [
+            bakery.Op(entity='something', action='read'),
+        ])
         self.assertEqual(len(self._discharges), 0)
         self.assertIsNotNone(auth_info)
         self.assertIsNone(auth_info.identity)
@@ -37,25 +37,23 @@ class TestChecker(TestCase):
     def test_authorization_denied(self):
         locator = _DischargerLocator()
         ids = _IdService('ids', locator, self)
-        auth = macaroonbakery.ClosedAuthorizer()
+        auth = bakery.ClosedAuthorizer()
         ts = _Service('myservice', auth, ids, locator)
         client = _Client(locator)
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'bob')
-        with self.assertRaises(macaroonbakery.PermissionDenied):
-            client.do(ctx, ts, [macaroonbakery.Op(entity='something',
-                                                  action='read')])
+        with self.assertRaises(bakery.PermissionDenied):
+            client.do(ctx, ts, [bakery.Op(entity='something', action='read')])
 
     def test_authorize_with_authentication_required(self):
         locator = _DischargerLocator()
         ids = _IdService('ids', locator, self)
         auth = _OpAuthorizer(
-            {macaroonbakery.Op(entity='something', action='read'): {'bob'}})
+            {bakery.Op(entity='something', action='read'): {'bob'}})
         ts = _Service('myservice', auth, ids, locator)
         client = _Client(locator)
 
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'bob')
-        auth_info = client.do(ctx, ts, [macaroonbakery.Op(entity='something',
-                                                          action='read')])
+        auth_info = client.do(ctx, ts, [bakery.Op(entity='something', action='read')])
         self.assertEqual(self._discharges,
                          [_DischargeRecord(location='ids', user='bob')])
         self.assertIsNotNone(auth_info)
@@ -67,16 +65,16 @@ class TestChecker(TestCase):
         ids = _IdService('ids', locator, self)
         auth = _OpAuthorizer(
             {
-                macaroonbakery.Op(entity='something', action='read'): {'bob'},
-                macaroonbakery.Op(entity='otherthing', action='read'): {'bob'}
+                bakery.Op(entity='something', action='read'): {'bob'},
+                bakery.Op(entity='otherthing', action='read'): {'bob'}
             }
         )
         ts = _Service('myservice', auth, ids, locator)
         client = _Client(locator)
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'bob')
         client.do(ctx, ts, [
-            macaroonbakery.Op(entity='something', action='read'),
-            macaroonbakery.Op(entity='otherthing', action='read')
+            bakery.Op(entity='something', action='read'),
+            bakery.Op(entity='otherthing', action='read')
         ])
         self.assertEqual(self._discharges,
                          [_DischargeRecord(location='ids', user='bob')])
@@ -85,159 +83,150 @@ class TestChecker(TestCase):
         locator = _DischargerLocator()
         ids = _IdService('ids', locator, self)
         auth = _OpAuthorizer(
-            {macaroonbakery.Op(entity='something', action='read'): {'bob'}})
+            {bakery.Op(entity='something', action='read'): {'bob'}})
         ts = _Service('myservice', auth, ids, locator)
         client = _Client(locator)
 
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'bob')
         m = client.discharged_capability(
-            ctx, ts, [macaroonbakery.Op(entity='something', action='read')])
+            ctx, ts, [bakery.Op(entity='something', action='read')])
         # Check that we can exercise the capability directly on the service
         # with no discharging required.
-        auth_info = ts.do(test_context, [m],
-                          [macaroonbakery.Op(entity='something',
-                                             action='read')])
+        auth_info = ts.do(test_context, [m], [
+            bakery.Op(entity='something', action='read'),
+        ])
         self.assertIsNotNone(auth_info)
         self.assertIsNone(auth_info.identity)
         self.assertEqual(len(auth_info.macaroons), 1)
-        self.assertEqual(auth_info.macaroons[0][0].identifier_bytes,
-                         m[0].identifier_bytes)
+        self.assertEqual(auth_info.macaroons[0][0].identifier_bytes, m[0].identifier_bytes)
 
     def test_capability_multiple_entities(self):
         locator = _DischargerLocator()
         ids = _IdService('ids', locator, self)
-        auth = _OpAuthorizer(
-            {
-                macaroonbakery.Op(entity='e1', action='read'): {'bob'},
-                macaroonbakery.Op(entity='e2', action='read'): {'bob'},
-                macaroonbakery.Op(entity='e3', action='read'): {'bob'},
-            })
+        auth = _OpAuthorizer({
+            bakery.Op(entity='e1', action='read'): {'bob'},
+            bakery.Op(entity='e2', action='read'): {'bob'},
+            bakery.Op(entity='e3', action='read'): {'bob'},
+        })
         ts = _Service('myservice', auth, ids, locator)
         client = _Client(locator)
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'bob')
         m = client.discharged_capability(ctx, ts, [
-                                         macaroonbakery.Op(entity='e1',
-                                                           action='read'),
-                                         macaroonbakery.Op(entity='e2',
-                                                           action='read'),
-                                         macaroonbakery.Op(entity='e3',
-                                                           action='read')])
+            bakery.Op(entity='e1', action='read'),
+            bakery.Op(entity='e2', action='read'),
+            bakery.Op(entity='e3', action='read'),
+        ])
         self.assertEqual(self._discharges,
                          [_DischargeRecord(location='ids', user='bob')])
 
         # Check that we can exercise the capability directly on the service
         # with no discharging required.
         ts.do(test_context, [m], [
-              macaroonbakery.Op(entity='e1', action='read'),
-              macaroonbakery.Op(entity='e2', action='read'),
-              macaroonbakery.Op(entity='e3', action='read')])
+            bakery.Op(entity='e1', action='read'),
+            bakery.Op(entity='e2', action='read'),
+            bakery.Op(entity='e3', action='read'),
+        ])
 
         # Check that we can exercise the capability to act on a subset of
         # the operations.
         ts.do(test_context, [m], [
-            macaroonbakery.Op(entity='e2', action='read'),
-            macaroonbakery.Op(entity='e3', action='read')]
-        )
+            bakery.Op(entity='e2', action='read'),
+            bakery.Op(entity='e3', action='read'),
+        ])
         ts.do(test_context, [m],
-              [macaroonbakery.Op(entity='e3', action='read')])
+              [bakery.Op(entity='e3', action='read')])
 
     def test_multiple_capabilities(self):
         locator = _DischargerLocator()
         ids = _IdService('ids', locator, self)
-        auth = _OpAuthorizer(
-            {
-                macaroonbakery.Op(entity='e1', action='read'): {'alice'},
-                macaroonbakery.Op(entity='e2', action='read'): {'bob'},
-            })
+        auth = _OpAuthorizer({
+            bakery.Op(entity='e1', action='read'): {'alice'},
+            bakery.Op(entity='e2', action='read'): {'bob'},
+        })
         ts = _Service('myservice', auth, ids, locator)
 
         # Acquire two capabilities as different users and check
         # that we can combine them together to do both operations
         # at once.
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'alice')
-        m1 = _Client(locator).discharged_capability(ctx, ts,
-                                                    [macaroonbakery.Op(
-                                                        entity='e1',
-                                                        action='read')])
+        m1 = _Client(locator).discharged_capability(ctx, ts, [
+            bakery.Op(entity='e1', action='read'),
+        ])
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'bob')
         m2 = _Client(locator).discharged_capability(ctx, ts,
-                                                    [macaroonbakery.Op(
+                                                    [bakery.Op(
                                                         entity='e2',
                                                         action='read')])
-        self.assertEqual(self._discharges,
-                         [
-                             _DischargeRecord(location='ids', user='alice'),
-                             _DischargeRecord(location='ids', user='bob'),
-                         ])
+        self.assertEqual(self._discharges, [
+            _DischargeRecord(location='ids', user='alice'),
+            _DischargeRecord(location='ids', user='bob'),
+        ])
         auth_info = ts.do(test_context, [m1, m2], [
-                          macaroonbakery.Op(entity='e1', action='read'),
-                          macaroonbakery.Op(entity='e2', action='read')])
+            bakery.Op(entity='e1', action='read'),
+            bakery.Op(entity='e2', action='read'),
+        ])
         self.assertIsNotNone(auth_info)
         self.assertIsNone(auth_info.identity)
         self.assertEqual(len(auth_info.macaroons), 2)
-        self.assertEqual(auth_info.macaroons[0][0].identifier_bytes,
-                         m1[0].identifier_bytes)
-        self.assertEqual(auth_info.macaroons[1][0].identifier_bytes,
-                         m2[0].identifier_bytes)
+        self.assertEqual(auth_info.macaroons[0][0].identifier_bytes, m1[0].identifier_bytes)
+        self.assertEqual(auth_info.macaroons[1][0].identifier_bytes, m2[0].identifier_bytes)
 
     def test_combine_capabilities(self):
         locator = _DischargerLocator()
         ids = _IdService('ids', locator, self)
-        auth = _OpAuthorizer(
-            {
-                macaroonbakery.Op(entity='e1', action='read'): {'alice'},
-                macaroonbakery.Op(entity='e2', action='read'): {'bob'},
-                macaroonbakery.Op(entity='e3', action='read'): {'bob',
-                                                                'alice'},
-            })
+        auth = _OpAuthorizer({
+            bakery.Op(entity='e1', action='read'): {'alice'},
+            bakery.Op(entity='e2', action='read'): {'bob'},
+            bakery.Op(entity='e3', action='read'): {'bob', 'alice'},
+        })
         ts = _Service('myservice', auth, ids, locator)
 
         # Acquire two capabilities as different users and check
         # that we can combine them together into a single capability
         # capable of both operations.
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'alice')
-        m1 = _Client(locator).discharged_capability(
-            ctx, ts, [
-                macaroonbakery.Op(entity='e1', action='read'),
-                macaroonbakery.Op(entity='e3', action='read')])
+        m1 = _Client(locator).discharged_capability(ctx, ts, [
+            bakery.Op(entity='e1', action='read'),
+            bakery.Op(entity='e3', action='read'),
+        ])
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'bob')
         m2 = _Client(locator).discharged_capability(
-            ctx, ts, [macaroonbakery.Op(entity='e2', action='read')])
+            ctx, ts, [bakery.Op(entity='e2', action='read')])
 
         m = ts.capability(test_context, [m1, m2], [
-                          macaroonbakery.Op(entity='e1', action='read'),
-                          macaroonbakery.Op(entity='e2', action='read'),
-                          macaroonbakery.Op(entity='e3', action='read')])
+            bakery.Op(entity='e1', action='read'),
+            bakery.Op(entity='e2', action='read'),
+            bakery.Op(entity='e3', action='read'),
+        ])
         ts.do(test_context, [[m.macaroon]], [
-              macaroonbakery.Op(entity='e1', action='read'),
-              macaroonbakery.Op(entity='e2', action='read'),
-              macaroonbakery.Op(entity='e3', action='read')])
+            bakery.Op(entity='e1', action='read'),
+            bakery.Op(entity='e2', action='read'),
+            bakery.Op(entity='e3', action='read'),
+        ])
 
     def test_partially_authorized_request(self):
         locator = _DischargerLocator()
         ids = _IdService('ids', locator, self)
-        auth = _OpAuthorizer(
-            {
-                macaroonbakery.Op(entity='e1', action='read'): {'alice'},
-                macaroonbakery.Op(entity='e2', action='read'): {'bob'},
-            })
+        auth = _OpAuthorizer({
+            bakery.Op(entity='e1', action='read'): {'alice'},
+            bakery.Op(entity='e2', action='read'): {'bob'},
+        })
         ts = _Service('myservice', auth, ids, locator)
 
         # Acquire a capability for e1 but rely on authentication to
         # authorize e2.
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'alice')
-        m = _Client(locator).discharged_capability(ctx, ts,
-                                                   [macaroonbakery.Op(
-                                                       entity='e1',
-                                                       action='read')])
+        m = _Client(locator).discharged_capability(ctx, ts, [
+            bakery.Op(entity='e1', action='read'),
+        ])
         client = _Client(locator)
         client.add_macaroon(ts, 'authz', m)
 
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'bob')
-        client.discharged_capability(
-            ctx, ts, [
-                macaroonbakery.Op(entity='e1', action='read'),
-                macaroonbakery.Op(entity='e2', action='read')])
+        client.discharged_capability(ctx, ts, [
+            bakery.Op(entity='e1', action='read'),
+            bakery.Op(entity='e2', action='read'),
+        ])
 
     def test_auth_with_third_party_caveats(self):
         locator = _DischargerLocator()
@@ -247,16 +236,15 @@ class TestChecker(TestCase):
         # when authorizing.
         def authorize_with_tp_discharge(ctx, id, op):
             if (id is not None and id.id() == 'bob' and
-                    op == macaroonbakery.Op(entity='something',
-                                            action='read')):
+                    op == bakery.Op(entity='something', action='read')):
                 return True, [checkers.Caveat(condition='question',
                                               location='other third party')]
             return False, None
 
-        auth = macaroonbakery.AuthorizerFunc(authorize_with_tp_discharge)
+        auth = bakery.AuthorizerFunc(authorize_with_tp_discharge)
         ts = _Service('myservice', auth, ids, locator)
 
-        class _LocalDischargeChecker(macaroonbakery.ThirdPartyCaveatChecker):
+        class _LocalDischargeChecker(bakery.ThirdPartyCaveatChecker):
             def check_third_party_caveat(_, ctx, info):
                 if info.condition != 'question':
                     raise ValueError('third party condition not recognized')
@@ -267,29 +255,25 @@ class TestChecker(TestCase):
                 return []
 
         locator['other third party'] = _Discharger(
-            key=macaroonbakery.generate_key(),
+            key=bakery.generate_key(),
             checker=_LocalDischargeChecker(),
             locator=locator,
         )
         client = _Client(locator)
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'bob')
-        client.do(ctx, ts, [macaroonbakery.Op(entity='something',
-                                              action='read')])
+        client.do(ctx, ts, [bakery.Op(entity='something', action='read')])
         self.assertEqual(self._discharges, [
             _DischargeRecord(location='ids', user='bob'),
-            _DischargeRecord(location='other third party',
-                             user='bob')
+            _DischargeRecord(location='other third party', user='bob')
         ])
 
     def test_capability_combines_first_party_caveats(self):
         locator = _DischargerLocator()
         ids = _IdService('ids', locator, self)
-        auth = _OpAuthorizer(
-            {
-                macaroonbakery.Op(entity='e1', action='read'): {'alice'},
-                macaroonbakery.Op(entity='e2', action='read'): {'bob'}
-            }
-        )
+        auth = _OpAuthorizer({
+            bakery.Op(entity='e1', action='read'): {'alice'},
+            bakery.Op(entity='e2', action='read'): {'bob'},
+        })
         ts = _Service('myservice', auth, ids, locator)
 
         # Acquire two capabilities as different users, add some first party
@@ -297,12 +281,12 @@ class TestChecker(TestCase):
         # capable of both operations.
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'alice')
         m1 = _Client(locator).capability(
-            ctx, ts, [macaroonbakery.Op(entity='e1', action='read')])
+            ctx, ts, [bakery.Op(entity='e1', action='read')])
         m1.macaroon.add_first_party_caveat('true 1')
         m1.macaroon.add_first_party_caveat('true 2')
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'bob')
         m2 = _Client(locator).capability(
-            ctx, ts, [macaroonbakery.Op(entity='e2', action='read')])
+            ctx, ts, [bakery.Op(entity='e2', action='read')])
         m2.macaroon.add_first_party_caveat('true 3')
         m2.macaroon.add_first_party_caveat('true 4')
 
@@ -311,8 +295,9 @@ class TestChecker(TestCase):
         client.add_macaroon(ts, 'authz2', [m2.macaroon])
 
         m = client.capability(test_context, ts, [
-                              macaroonbakery.Op(entity='e1', action='read'),
-                              macaroonbakery.Op(entity='e2', action='read')])
+            bakery.Op(entity='e1', action='read'),
+            bakery.Op(entity='e2', action='read'),
+        ])
         self.assertEqual(_macaroon_conditions(m.macaroon.caveats, False), [
             'true 1',
             'true 2',
@@ -323,11 +308,10 @@ class TestChecker(TestCase):
     def test_first_party_caveat_squashing(self):
         locator = _DischargerLocator()
         ids = _IdService('ids', locator, self)
-        auth = _OpAuthorizer(
-            {
-                macaroonbakery.Op(entity='e1', action='read'): {'alice'},
-                macaroonbakery.Op(entity='e2', action='read'): {'alice'},
-            })
+        auth = _OpAuthorizer({
+            bakery.Op(entity='e1', action='read'): {'alice'},
+            bakery.Op(entity='e2', action='read'): {'alice'},
+        })
         ts = _Service('myservice', auth, ids, locator)
         tests = [
             ('duplicates removed', [
@@ -366,13 +350,13 @@ class TestChecker(TestCase):
             # Make a first macaroon with all the required first party caveats.
             ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'alice')
             m1 = _Client(locator).capability(
-                ctx, ts, [macaroonbakery.Op(entity='e1', action='read')])
+                ctx, ts, [bakery.Op(entity='e1', action='read')])
             m1.add_caveats(test[1], None, None)
 
             # Make a second macaroon that's not used to check that it's
             # caveats are not added.
             m2 = _Client(locator).capability(
-                ctx, ts, [macaroonbakery.Op(entity='e1', action='read')])
+                ctx, ts, [bakery.Op(entity='e1', action='read')])
             m2.add_caveat(checkers.Caveat(
                 condition='true notused', namespace='testns'), None, None)
             client = _Client(locator)
@@ -380,8 +364,7 @@ class TestChecker(TestCase):
             client.add_macaroon(ts, 'authz2', [m2.macaroon])
 
             m3 = client.capability(
-                test_context, ts, [macaroonbakery.Op(entity='e1',
-                                                     action='read')])
+                test_context, ts, [bakery.Op(entity='e1', action='read')])
             self.assertEqual(
                 _macaroon_conditions(m3.macaroon.caveats, False),
                 _resolve_caveats(m3.namespace, test[2]))
@@ -389,11 +372,11 @@ class TestChecker(TestCase):
     def test_login_only(self):
         locator = _DischargerLocator()
         ids = _IdService('ids', locator, self)
-        auth = macaroonbakery.ClosedAuthorizer()
+        auth = bakery.ClosedAuthorizer()
         ts = _Service('myservice', auth, ids, locator)
 
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'bob')
-        auth_info = _Client(locator).do(ctx, ts, [macaroonbakery.LOGIN_OP])
+        auth_info = _Client(locator).do(ctx, ts, [bakery.LOGIN_OP])
         self.assertIsNotNone(auth_info)
         self.assertEqual(auth_info.identity.id(), 'bob')
 
@@ -402,18 +385,17 @@ class TestChecker(TestCase):
         ids = _IdService('ids', locator, self)
         auth = _OpAuthorizer(
             {
-                macaroonbakery.Op(entity='e1', action='read'): {'alice'},
-                macaroonbakery.Op(entity='e2', action='read'): {'bob'},
+                bakery.Op(entity='e1', action='read'): {'alice'},
+                bakery.Op(entity='e2', action='read'): {'bob'},
             })
         ts = _Service('myservice', auth, ids, locator)
 
         # Acquire a capability for e1 but rely on authentication to
         # authorize e2.
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'alice')
-        m = _Client(locator).discharged_capability(ctx, ts,
-                                                   [macaroonbakery.Op(
-                                                       entity='e1',
-                                                       action='read')])
+        m = _Client(locator).discharged_capability(ctx, ts, [
+            bakery.Op(entity='e1', action='read'),
+        ])
 
         client = _Client(locator)
         client.add_macaroon(ts, 'authz', m)
@@ -423,24 +405,22 @@ class TestChecker(TestCase):
         with self.assertRaises(_DischargeRequiredError):
             client.do_any(
                 ctx, ts, [
-                    macaroonbakery.LOGIN_OP,
-                    macaroonbakery.Op(entity='e1', action='read'),
-                    macaroonbakery.Op(entity='e1', action='read')
+                    bakery.LOGIN_OP,
+                    bakery.Op(entity='e1', action='read'),
+                    bakery.Op(entity='e1', action='read')
                 ]
             )
             self.assertEqual(len(self._discharges), 0)
 
         # Log in as bob.
-        _, err = client.do(ctx, ts, [macaroonbakery.LOGIN_OP])
+        _, err = client.do(ctx, ts, [bakery.LOGIN_OP])
 
         # All the previous actions should now be allowed.
-        auth_info, allowed = client.do_any(
-            ctx, ts, [
-                macaroonbakery.LOGIN_OP,
-                macaroonbakery.Op(entity='e1', action='read'),
-                macaroonbakery.Op(entity='e1', action='read')
-            ]
-        )
+        auth_info, allowed = client.do_any(ctx, ts, [
+            bakery.LOGIN_OP,
+            bakery.Op(entity='e1', action='read'),
+            bakery.Op(entity='e1', action='read'),
+        ])
         self.assertEqual(auth_info.identity.id(), 'bob')
         self.assertEqual(len(auth_info.macaroons), 2)
         self.assertEqual(allowed, [True, True, True])
@@ -448,123 +428,121 @@ class TestChecker(TestCase):
     def test_auth_with_identity_from_context(self):
         locator = _DischargerLocator()
         ids = _BasicAuthIdService()
-        auth = _OpAuthorizer(
-            {
-                macaroonbakery.Op(entity='e1', action='read'): {'sherlock'},
-                macaroonbakery.Op(entity='e2', action='read'): {'bob'},
-            })
+        auth = _OpAuthorizer({
+            bakery.Op(entity='e1', action='read'): {'sherlock'},
+            bakery.Op(entity='e2', action='read'): {'bob'},
+        })
         ts = _Service('myservice', auth, ids, locator)
 
         # Check that we can perform the ops with basic auth in the
         # context.
         ctx = _context_with_basic_auth(test_context, 'sherlock', 'holmes')
         auth_info = _Client(locator).do(
-            ctx, ts, [macaroonbakery.Op(entity='e1', action='read')])
+            ctx, ts, [bakery.Op(entity='e1', action='read')])
         self.assertEqual(auth_info.identity.id(), 'sherlock')
         self.assertEqual(len(auth_info.macaroons), 0)
 
     def test_auth_login_op_with_identity_from_context(self):
         locator = _DischargerLocator()
         ids = _BasicAuthIdService()
-        ts = _Service('myservice', macaroonbakery.ClosedAuthorizer(),
-                      ids, locator)
+        ts = _Service('myservice', bakery.ClosedAuthorizer(), ids, locator)
 
         # Check that we can use LoginOp
         # when auth isn't granted through macaroons.
         ctx = _context_with_basic_auth(test_context, 'sherlock', 'holmes')
-        auth_info = _Client(locator).do(ctx, ts, [macaroonbakery.LOGIN_OP])
+        auth_info = _Client(locator).do(ctx, ts, [bakery.LOGIN_OP])
         self.assertEqual(auth_info.identity.id(), 'sherlock')
         self.assertEqual(len(auth_info.macaroons), 0)
 
     def test_operation_allow_caveat(self):
         locator = _DischargerLocator()
         ids = _IdService('ids', locator, self)
-        auth = _OpAuthorizer(
-            {
-                macaroonbakery.Op(entity='e1', action='read'): {'bob'},
-                macaroonbakery.Op(entity='e1', action='write'): {'bob'},
-                macaroonbakery.Op(entity='e2', action='read'): {'bob'},
-            })
+        auth = _OpAuthorizer({
+            bakery.Op(entity='e1', action='read'): {'bob'},
+            bakery.Op(entity='e1', action='write'): {'bob'},
+            bakery.Op(entity='e2', action='read'): {'bob'},
+        })
         ts = _Service('myservice', auth, ids, locator)
         client = _Client(locator)
 
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'bob')
-        m = client.capability(
-            ctx, ts, [
-                macaroonbakery.Op(entity='e1', action='read'),
-                macaroonbakery.Op(entity='e1', action='write'),
-                macaroonbakery.Op(entity='e2', action='read')])
+        m = client.capability(ctx, ts, [
+            bakery.Op(entity='e1', action='read'),
+            bakery.Op(entity='e1', action='write'),
+            bakery.Op(entity='e2', action='read'),
+        ])
 
         # Sanity check that we can do a write.
         ts.do(test_context, [[m.macaroon]],
-              [macaroonbakery.Op(entity='e1', action='write')])
+              [bakery.Op(entity='e1', action='write')])
 
         m.add_caveat(checkers.allow_caveat(['read']), None, None)
 
         # A read operation should work.
         ts.do(test_context, [[m.macaroon]], [
-              macaroonbakery.Op(entity='e1', action='read'),
-              macaroonbakery.Op(entity='e2', action='read')])
+            bakery.Op(entity='e1', action='read'),
+            bakery.Op(entity='e2', action='read'),
+        ])
 
         # A write operation should fail
         # even though the original macaroon allowed it.
         with self.assertRaises(_DischargeRequiredError):
             ts.do(test_context, [[m.macaroon]], [
-                  macaroonbakery.Op(entity='e1', action='write')])
+                bakery.Op(entity='e1', action='write'),
+            ])
 
     def test_operation_deny_caveat(self):
         locator = _DischargerLocator()
         ids = _IdService('ids', locator, self)
-        auth = _OpAuthorizer(
-            {
-                macaroonbakery.Op(entity='e1', action='read'): {'bob'},
-                macaroonbakery.Op(entity='e1', action='write'): {'bob'},
-                macaroonbakery.Op(entity='e2', action='read'): {'bob'},
-            })
+        auth = _OpAuthorizer({
+            bakery.Op(entity='e1', action='read'): {'bob'},
+            bakery.Op(entity='e1', action='write'): {'bob'},
+            bakery.Op(entity='e2', action='read'): {'bob'},
+        })
         ts = _Service('myservice', auth, ids, locator)
         client = _Client(locator)
 
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'bob')
-        m = client.capability(
-            ctx, ts, [
-                macaroonbakery.Op(entity='e1', action='read'),
-                macaroonbakery.Op(entity='e1', action='write'),
-                macaroonbakery.Op(entity='e2', action='read')])
+        m = client.capability(ctx, ts, [
+            bakery.Op(entity='e1', action='read'),
+            bakery.Op(entity='e1', action='write'),
+            bakery.Op(entity='e2', action='read'),
+        ])
 
         # Sanity check that we can do a write.
         ts.do(test_context, [[m.macaroon]], [
-              macaroonbakery.Op(entity='e1', action='write')])
+              bakery.Op(entity='e1', action='write')])
 
         m.add_caveat(checkers.deny_caveat(['write']), None, None)
 
         # A read operation should work.
-        ts.do(
-            test_context, [[m.macaroon]], [
-                macaroonbakery.Op(entity='e1', action='read'),
-                macaroonbakery.Op(entity='e2', action='read')])
+        ts.do(test_context, [[m.macaroon]], [
+            bakery.Op(entity='e1', action='read'),
+            bakery.Op(entity='e2', action='read'),
+        ])
 
         # A write operation should fail
         # even though the original macaroon allowed it.
         with self.assertRaises(_DischargeRequiredError):
             ts.do(test_context, [[m.macaroon]], [
-                  macaroonbakery.Op(entity='e1', action='write')])
+                  bakery.Op(entity='e1', action='write')])
 
     def test_duplicate_login_macaroons(self):
         locator = _DischargerLocator()
         ids = _IdService('ids', locator, self)
-        auth = macaroonbakery.ClosedAuthorizer()
+        auth = bakery.ClosedAuthorizer()
         ts = _Service('myservice', auth, ids, locator)
 
         # Acquire a login macaroon for bob.
         client1 = _Client(locator)
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'bob')
-        auth_info = client1.do(ctx, ts, [macaroonbakery.LOGIN_OP])
+        auth_info = client1.do(ctx, ts, [bakery.LOGIN_OP])
         self.assertEqual(auth_info.identity.id(), 'bob')
 
         # Acquire a login macaroon for alice.
         client2 = _Client(locator)
         ctx = test_context.with_value(_DISCHARGE_USER_KEY, 'alice')
-        auth_info = client2.do(ctx, ts, [macaroonbakery.LOGIN_OP])
+        auth_info = client2.do(ctx, ts, [bakery.LOGIN_OP])
         self.assertEqual(auth_info.identity.id(), 'alice')
 
         # Combine the two login macaroons into one client.
@@ -576,32 +554,30 @@ class TestChecker(TestCase):
 
         # We should authenticate as bob (because macaroons are presented
         # ordered by "cookie" name)
-        auth_info = client3.do(test_context, ts, [macaroonbakery.LOGIN_OP])
+        auth_info = client3.do(test_context, ts, [bakery.LOGIN_OP])
         self.assertEqual(auth_info.identity.id(), 'bob')
         self.assertEqual(len(auth_info.macaroons), 1)
 
         # Try them the other way around and we should authenticate as alice.
         client3 = _Client(locator)
-        client3.add_macaroon(ts, '1.alice',
-                             client2._macaroons[ts.name()]['authn'])
-        client3.add_macaroon(ts, '2.bob',
-                             client1._macaroons[ts.name()]['authn'])
+        client3.add_macaroon(ts, '1.alice', client2._macaroons[ts.name()]['authn'])
+        client3.add_macaroon(ts, '2.bob', client1._macaroons[ts.name()]['authn'])
 
-        auth_info = client3.do(test_context, ts, [macaroonbakery.LOGIN_OP])
+        auth_info = client3.do(test_context, ts, [bakery.LOGIN_OP])
         self.assertEqual(auth_info.identity.id(), 'alice')
         self.assertEqual(len(auth_info.macaroons), 1)
 
     def test_macaroon_ops_fatal_error(self):
         # When we get a non-VerificationError error from the
         # opstore, we don't do any more verification.
-        checker = macaroonbakery.Checker(
+        checker = bakery.Checker(
             macaroon_opstore=_MacaroonStoreWithError())
         m = pymacaroons.Macaroon(version=pymacaroons.MACAROON_V2)
-        with self.assertRaises(macaroonbakery.AuthInitError):
-            checker.auth([m]).allow(test_context, [macaroonbakery.LOGIN_OP])
+        with self.assertRaises(bakery.AuthInitError):
+            checker.auth([m]).allow(test_context, [bakery.LOGIN_OP])
 
 
-class _DischargerLocator(macaroonbakery.ThirdPartyLocator):
+class _DischargerLocator(bakery.ThirdPartyLocator):
     def __init__(self, dischargers=None):
         if dischargers is None:
             dischargers = {}
@@ -611,9 +587,9 @@ class _DischargerLocator(macaroonbakery.ThirdPartyLocator):
         d = self._dischargers.get(loc)
         if d is None:
             return None
-        return macaroonbakery.ThirdPartyInfo(
+        return bakery.ThirdPartyInfo(
             public_key=d._key.public_key,
-            version=macaroonbakery.LATEST_BAKERY_VERSION,
+            version=bakery.LATEST_BAKERY_VERSION,
         )
 
     def __setitem__(self, key, item):
@@ -626,24 +602,23 @@ class _DischargerLocator(macaroonbakery.ThirdPartyLocator):
         return self._dischargers.get(key)
 
 
-class _IdService(macaroonbakery.IdentityClient,
-                 macaroonbakery.ThirdPartyCaveatChecker):
+class _IdService(bakery.IdentityClient,
+                 bakery.ThirdPartyCaveatChecker):
     def __init__(self, location, locator, test_class):
         self._location = location
         self._test = test_class
-        key = macaroonbakery.generate_key()
+        key = bakery.generate_key()
         self._discharger = _Discharger(key=key, checker=self, locator=locator)
         locator[location] = self._discharger
 
     def check_third_party_caveat(self, ctx, info):
         if info.condition != 'is-authenticated-user':
-            raise macaroonbakery.CaveatNotRecognizedError(
+            raise bakery.CaveatNotRecognizedError(
                 'third party condition not recognized')
 
         username = ctx.get(_DISCHARGE_USER_KEY, '')
         if username == '':
-            raise macaroonbakery.ThirdPartyCaveatCheckFailed(
-                'no current user')
+            raise bakery.ThirdPartyCaveatCheckFailed('no current user')
         self._test._discharges.append(
             _DischargeRecord(location=self._location, user=username))
         return [checkers.declared_caveat('username', username)]
@@ -655,8 +630,8 @@ class _IdService(macaroonbakery.IdentityClient,
     def declared_identity(self, ctx, declared):
         user = declared.get('username')
         if user is None:
-            raise macaroonbakery.IdentityError('no username declared')
-        return macaroonbakery.SimpleIdentity(user)
+            raise bakery.IdentityError('no username declared')
+        return bakery.SimpleIdentity(user)
 
 
 _DISCHARGE_USER_KEY = checkers.ContextKey('user-key')
@@ -675,7 +650,7 @@ class _Discharger(object):
         self._checker = checker
 
     def discharge(self, ctx, cav, payload):
-        return macaroonbakery.discharge(
+        return bakery.discharge(
             ctx,
             key=self._key,
             id=cav.caveat_id,
@@ -685,7 +660,7 @@ class _Discharger(object):
         )
 
 
-class _OpAuthorizer(macaroonbakery.Authorizer):
+class _OpAuthorizer(bakery.Authorizer):
     '''Implements bakery.Authorizer by looking the operation
     up in the given map. If the username is in the associated list
     or the list contains "everyone", authorization is granted.
@@ -697,7 +672,7 @@ class _OpAuthorizer(macaroonbakery.Authorizer):
         self._auth = auth
 
     def authorize(self, ctx, id, ops):
-        return macaroonbakery.ACLAuthorizer(
+        return bakery.ACLAuthorizer(
             allow_public=True,
             get_acl=lambda ctx, op: self._auth.get(op, [])).authorize(
             ctx, id, ops)
@@ -708,7 +683,7 @@ class _MacaroonStore(object):
     '''
 
     def __init__(self, key, locator):
-        self._root_key_store = macaroonbakery.MemoryKeyStore()
+        self._root_key_store = bakery.MemoryKeyStore()
         self._key = key
         self._locator = locator
 
@@ -716,9 +691,9 @@ class _MacaroonStore(object):
         root_key, id = self._root_key_store.root_key()
         m_id = {'id': base64.urlsafe_b64encode(id).decode('utf-8'), 'ops': ops}
         data = json.dumps(m_id)
-        m = macaroonbakery.Macaroon(
+        m = bakery.Macaroon(
             root_key=root_key, id=data, location='',
-            version=macaroonbakery.LATEST_BAKERY_VERSION,
+            version=bakery.LATEST_BAKERY_VERSION,
             namespace=namespace)
         m.add_caveats(caveats, self._key, self._locator)
         return m
@@ -742,7 +717,7 @@ class _MacaroonStore(object):
         ok = v.verify(macaroon=ms[0], key=root_key,
                       discharge_macaroons=ms[1:])
         if not ok:
-            raise macaroonbakery.VerificationError('invalid signature')
+            raise bakery.VerificationError('invalid signature')
         conditions = []
         for m in ms:
             cavs = m.first_party_caveats()
@@ -750,7 +725,7 @@ class _MacaroonStore(object):
                 conditions.append(cav.caveat_id_bytes.decode('utf-8'))
         ops = []
         for op in m_id['ops']:
-            ops.append(macaroonbakery.Op(entity=op[0], action=op[1]))
+            ops.append(bakery.Op(entity=op[0], action=op[1]))
         return ops, conditions
 
 
@@ -764,8 +739,8 @@ class _Service(object):
 
     def __init__(self, name, auth, idm, locator):
         self._name = name
-        self._store = _MacaroonStore(macaroonbakery.generate_key(), locator)
-        self._checker = macaroonbakery.Checker(
+        self._store = _MacaroonStore(bakery.generate_key(), locator)
+        self._checker = bakery.Checker(
             checker=test_checker(),
             authorizer=auth,
             identity_client=idm,
@@ -777,7 +752,7 @@ class _Service(object):
     def do(self, ctx, ms, ops):
         try:
             authInfo = self._checker.auth(ms).allow(ctx, ops)
-        except macaroonbakery.DischargeRequiredError as exc:
+        except bakery.DischargeRequiredError as exc:
             self._discharge_required_error(exc)
         return authInfo
 
@@ -787,13 +762,13 @@ class _Service(object):
         try:
             authInfo, allowed = self._checker.auth(ms).allow_any(ctx, ops)
             return authInfo, allowed
-        except macaroonbakery.DischargeRequiredError as exc:
+        except bakery.DischargeRequiredError as exc:
             self._discharge_required_error(exc)
 
     def capability(self, ctx, ms, ops):
         try:
             conds = self._checker.auth(ms).allow_capability(ctx, ops)
-        except macaroonbakery.DischargeRequiredError as exc:
+        except bakery.DischargeRequiredError as exc:
             self._discharge_required_error(exc)
 
         m = self._store.new_macaroon(None, self._checker.namespace(), ops)
@@ -805,7 +780,7 @@ class _Service(object):
         m = self._store.new_macaroon(err.cavs(), self._checker.namespace(),
                                      err.ops())
         name = 'authz'
-        if len(err.ops()) == 1 and err.ops()[0] == macaroonbakery.LOGIN_OP:
+        if len(err.ops()) == 1 and err.ops()[0] == bakery.LOGIN_OP:
             name = 'authn'
         raise _DischargeRequiredError(name=name, m=m)
 
@@ -827,7 +802,7 @@ class _Client(object):
     max_retries = 3
 
     def __init__(self, dischargers):
-        self._key = macaroonbakery.generate_key()
+        self._key = bakery.generate_key()
         self._macaroons = {}
         self._dischargers = dischargers
 
@@ -904,19 +879,18 @@ class _Client(object):
                                  '{} not found'.format(cav.location))
             return d.discharge(ctx, cav, payload)
 
-        return macaroonbakery.discharge_all(m, get_discharge)
+        return bakery.discharge_all(m, get_discharge)
 
 
-class _BasicAuthIdService(macaroonbakery.IdentityClient):
+class _BasicAuthIdService(bakery.IdentityClient):
     def identity_from_context(self, ctx):
         user, pwd = _basic_auth_from_context(ctx)
         if user != 'sherlock' or pwd != 'holmes':
             return None, None
-        return macaroonbakery.SimpleIdentity(user), None
+        return bakery.SimpleIdentity(user), None
 
     def declared_identity(self, ctx, declared):
-        raise macaroonbakery.IdentityError('no identity declarations in basic '
-                                           'auth id service')
+        raise bakery.IdentityError('no identity declarations in basic auth id service')
 
 
 _BASIC_AUTH_KEY = checkers.ContextKey('user-key')

--- a/macaroonbakery/tests/test_codec.py
+++ b/macaroonbakery/tests/test_codec.py
@@ -6,95 +6,94 @@ from unittest import TestCase
 import nacl.public
 import six
 
-import macaroonbakery
-from macaroonbakery import utils
+import macaroonbakery as bakery
 from macaroonbakery import codec
 import macaroonbakery.checkers as checkers
 
 
 class TestCodec(TestCase):
     def setUp(self):
-        self.fp_key = macaroonbakery.generate_key()
-        self.tp_key = macaroonbakery.generate_key()
+        self.fp_key = bakery.generate_key()
+        self.tp_key = bakery.generate_key()
 
     def test_v1_round_trip(self):
-        tp_info = macaroonbakery.ThirdPartyInfo(
-            version=macaroonbakery.BAKERY_V1,
+        tp_info = bakery.ThirdPartyInfo(
+            version=bakery.BAKERY_V1,
             public_key=self.tp_key.public_key)
-        cid = macaroonbakery.encode_caveat(
+        cid = bakery.encode_caveat(
             'is-authenticated-user',
             b'a random string',
             tp_info,
             self.fp_key,
             None)
-        res = macaroonbakery.decode_caveat(self.tp_key, cid)
-        self.assertEquals(res, macaroonbakery.ThirdPartyCaveatInfo(
+        res = bakery.decode_caveat(self.tp_key, cid)
+        self.assertEquals(res, bakery.ThirdPartyCaveatInfo(
             first_party_public_key=self.fp_key.public_key,
             root_key=b'a random string',
             condition='is-authenticated-user',
             caveat=cid,
             third_party_key_pair=self.tp_key,
-            version=macaroonbakery.BAKERY_V1,
+            version=bakery.BAKERY_V1,
             id=None,
-            namespace=macaroonbakery.legacy_namespace()
+            namespace=bakery.legacy_namespace()
         ))
 
     def test_v2_round_trip(self):
-        tp_info = macaroonbakery.ThirdPartyInfo(
-            version=macaroonbakery.BAKERY_V2,
+        tp_info = bakery.ThirdPartyInfo(
+            version=bakery.BAKERY_V2,
             public_key=self.tp_key.public_key)
-        cid = macaroonbakery.encode_caveat(
+        cid = bakery.encode_caveat(
             'is-authenticated-user',
             b'a random string',
             tp_info,
             self.fp_key,
             None)
-        res = macaroonbakery.decode_caveat(self.tp_key, cid)
-        self.assertEquals(res, macaroonbakery.ThirdPartyCaveatInfo(
+        res = bakery.decode_caveat(self.tp_key, cid)
+        self.assertEquals(res, bakery.ThirdPartyCaveatInfo(
             first_party_public_key=self.fp_key.public_key,
             root_key=b'a random string',
             condition='is-authenticated-user',
             caveat=cid,
             third_party_key_pair=self.tp_key,
-            version=macaroonbakery.BAKERY_V2,
+            version=bakery.BAKERY_V2,
             id=None,
-            namespace=macaroonbakery.legacy_namespace()
+            namespace=bakery.legacy_namespace()
         ))
 
     def test_v3_round_trip(self):
-        tp_info = macaroonbakery.ThirdPartyInfo(
-            version=macaroonbakery.BAKERY_V3,
+        tp_info = bakery.ThirdPartyInfo(
+            version=bakery.BAKERY_V3,
             public_key=self.tp_key.public_key)
         ns = checkers.Namespace()
         ns.register('testns', 'x')
-        cid = macaroonbakery.encode_caveat(
+        cid = bakery.encode_caveat(
             'is-authenticated-user',
             b'a random string',
             tp_info,
             self.fp_key,
             ns)
-        res = macaroonbakery.decode_caveat(self.tp_key, cid)
-        self.assertEquals(res, macaroonbakery.ThirdPartyCaveatInfo(
+        res = bakery.decode_caveat(self.tp_key, cid)
+        self.assertEquals(res, bakery.ThirdPartyCaveatInfo(
             first_party_public_key=self.fp_key.public_key,
             root_key=b'a random string',
             condition='is-authenticated-user',
             caveat=cid,
             third_party_key_pair=self.tp_key,
-            version=macaroonbakery.BAKERY_V3,
+            version=bakery.BAKERY_V3,
             id=None,
             namespace=ns
         ))
 
     def test_empty_caveat_id(self):
-        with self.assertRaises(macaroonbakery.VerificationError) as context:
-            macaroonbakery.decode_caveat(self.tp_key, b'')
+        with self.assertRaises(bakery.VerificationError) as context:
+            bakery.decode_caveat(self.tp_key, b'')
         self.assertTrue('empty third party caveat' in str(context.exception))
 
     def test_decode_caveat_v1_from_go(self):
-        tp_key = macaroonbakery.PrivateKey(
+        tp_key = bakery.PrivateKey(
             nacl.public.PrivateKey(base64.b64decode(
                 'TSpvLpQkRj+T3JXnsW2n43n5zP/0X4zn0RvDiWC3IJ0=')))
-        fp_key = macaroonbakery.PrivateKey(
+        fp_key = bakery.PrivateKey(
             nacl.public.PrivateKey(base64.b64decode(
                 'KXpsoJ9ujZYi/O2Cca6kaWh65MSawzy79LWkrjOfzcs=')))
         root_key = base64.b64decode('vDxEmWZEkgiNEFlJ+8ruXe3qDSLf1H+o')
@@ -111,70 +110,70 @@ class TestCodec(TestCase):
             'BORldUUExGdjVla1dWUjA4Uk1sbGJhc3c4VGdFbkhzM0laeVo'
             '0V2lEOHhRUWdjU3ljOHY4eUt4dEhxejVEczJOYmh1ZDJhUFdt'
             'UTVMcVlNWitmZ2FNaTAxdE9DIn0=')
-        cav = macaroonbakery.decode_caveat(tp_key, encrypted_cav)
-        self.assertEquals(cav, macaroonbakery.ThirdPartyCaveatInfo(
+        cav = bakery.decode_caveat(tp_key, encrypted_cav)
+        self.assertEquals(cav, bakery.ThirdPartyCaveatInfo(
             condition='caveat condition',
             first_party_public_key=fp_key.public_key,
             third_party_key_pair=tp_key,
             root_key=root_key,
             caveat=encrypted_cav,
-            version=macaroonbakery.BAKERY_V1,
+            version=bakery.BAKERY_V1,
             id=None,
-            namespace=macaroonbakery.legacy_namespace()
+            namespace=bakery.legacy_namespace()
         ))
 
     def test_decode_caveat_v2_from_go(self):
-        tp_key = macaroonbakery.PrivateKey(nacl.public.PrivateKey(
+        tp_key = bakery.PrivateKey(nacl.public.PrivateKey(
             base64.b64decode(
                 'TSpvLpQkRj+T3JXnsW2n43n5zP/0X4zn0RvDiWC3IJ0=')))
-        fp_key = macaroonbakery.PrivateKey(
+        fp_key = bakery.PrivateKey(
             nacl.public.PrivateKey(base64.b64decode(
                 'KXpsoJ9ujZYi/O2Cca6kaWh65MSawzy79LWkrjOfzcs=')))
         root_key = base64.b64decode('wh0HSM65wWHOIxoGjgJJOFvQKn2jJFhC')
         # This caveat has been generated from the go code
         # to check the compatibilty
-        encrypted_cav = utils.b64decode(
+        encrypted_cav = bakery.b64decode(
             'AvD-xlUf2MdGMgtu7OKRQnCP1OQJk6PKeFWRK26WIBA6DNwKGIHq9xGcHS9IZ'
             'Lh0cL6D9qpeKI0mXmCPfnwRQDuVYC8y5gVWd-oCGZaj5TGtk3byp2Vnw6ojmt'
             'sULDhY59YA_J_Y0ATkERO5T9ajoRWBxU2OXBoX6bImXA',
         )
-        cav = macaroonbakery.decode_caveat(tp_key, encrypted_cav)
-        self.assertEqual(cav, macaroonbakery.ThirdPartyCaveatInfo(
+        cav = bakery.decode_caveat(tp_key, encrypted_cav)
+        self.assertEqual(cav, bakery.ThirdPartyCaveatInfo(
             condition='third party condition',
             first_party_public_key=fp_key.public_key,
             third_party_key_pair=tp_key,
             root_key=root_key,
             caveat=encrypted_cav,
-            version=macaroonbakery.BAKERY_V2,
+            version=bakery.BAKERY_V2,
             id=None,
-            namespace=macaroonbakery.legacy_namespace()
+            namespace=bakery.legacy_namespace()
         ))
 
     def test_decode_caveat_v3_from_go(self):
-        tp_key = macaroonbakery.PrivateKey(
+        tp_key = bakery.PrivateKey(
             nacl.public.PrivateKey(base64.b64decode(
                 'TSpvLpQkRj+T3JXnsW2n43n5zP/0X4zn0RvDiWC3IJ0=')))
-        fp_key = macaroonbakery.PrivateKey(nacl.public.PrivateKey(
+        fp_key = bakery.PrivateKey(nacl.public.PrivateKey(
             base64.b64decode(
                 'KXpsoJ9ujZYi/O2Cca6kaWh65MSawzy79LWkrjOfzcs=')))
         root_key = base64.b64decode(b'oqOXI3/Mz/pKjCuFOt2eYxb7ndLq66GY')
         # This caveat has been generated from the go code
         # to check the compatibilty
-        encrypted_cav = utils.b64decode(
+        encrypted_cav = bakery.b64decode(
             'A_D-xlUf2MdGMgtu7OKRQnCP1OQJk6PKeFWRK26WIBA6DNwKGNLeFSkD2M-8A'
             'EYvmgVH95GWu7T7caKxKhhOQFcEKgnXKJvYXxz1zin4cZc4Q6C7gVqA-J4_j3'
             '1LX4VKxymqG62UGPo78wOv0_fKjr3OI6PPJOYOQgBMclemlRF2',
         )
-        cav = macaroonbakery.decode_caveat(tp_key, encrypted_cav)
-        self.assertEquals(cav, macaroonbakery.ThirdPartyCaveatInfo(
+        cav = bakery.decode_caveat(tp_key, encrypted_cav)
+        self.assertEquals(cav, bakery.ThirdPartyCaveatInfo(
             condition='third party condition',
             first_party_public_key=fp_key.public_key,
             third_party_key_pair=tp_key,
             root_key=root_key,
             caveat=encrypted_cav,
-            version=macaroonbakery.BAKERY_V3,
+            version=bakery.BAKERY_V3,
             id=None,
-            namespace=macaroonbakery.legacy_namespace()
+            namespace=bakery.legacy_namespace()
         ))
 
     def test_encode_decode_varint(self):
@@ -189,7 +188,7 @@ class TestCodec(TestCase):
         for test in tests:
             data = bytearray()
             expected = bytearray()
-            macaroonbakery.encode_uvarint(test[0], data)
+            bakery.encode_uvarint(test[0], data)
             for v in test[1]:
                 expected.append(v)
             self.assertEquals(data, expected)

--- a/macaroonbakery/tests/test_discharge.py
+++ b/macaroonbakery/tests/test_discharge.py
@@ -4,9 +4,8 @@ import unittest
 
 from pymacaroons import MACAROON_V1, Macaroon
 
-import macaroonbakery
+import macaroonbakery as bakery
 import macaroonbakery.checkers as checkers
-from macaroonbakery.error import VerificationError
 from macaroonbakery.tests import common
 
 
@@ -18,15 +17,15 @@ class TestDischarge(unittest.TestCase):
         can verify this macaroon as valid.
         '''
         oc = common.new_bakery('bakerytest')
-        primary = oc.oven.macaroon(macaroonbakery.LATEST_BAKERY_VERSION,
+        primary = oc.oven.macaroon(bakery.LATEST_BAKERY_VERSION,
                                    common.ages, None,
-                                   [macaroonbakery.LOGIN_OP])
+                                   [bakery.LOGIN_OP])
         self.assertEqual(primary.macaroon.location, 'bakerytest')
         primary.add_caveat(checkers.Caveat(condition='str something',
                                            namespace='testns'),
                            oc.oven.key, oc.oven.locator)
         oc.checker.auth([[primary.macaroon]]).allow(
-            common.str_context('something'), [macaroonbakery.LOGIN_OP])
+            common.str_context('something'), [bakery.LOGIN_OP])
 
     def test_macaroon_paper_fig6(self):
         ''' Implements an example flow as described in the macaroons paper:
@@ -43,15 +42,15 @@ class TestDischarge(unittest.TestCase):
         The target service verifies the original macaroon it delegated to fs
         No direct contact between bs and ts is required
         '''
-        locator = macaroonbakery.ThirdPartyStore()
+        locator = bakery.ThirdPartyStore()
         bs = common.new_bakery('bs-loc', locator)
         ts = common.new_bakery('ts-loc', locator)
         fs = common.new_bakery('fs-loc', locator)
 
         # ts creates a macaroon.
-        ts_macaroon = ts.oven.macaroon(macaroonbakery.LATEST_BAKERY_VERSION,
+        ts_macaroon = ts.oven.macaroon(bakery.LATEST_BAKERY_VERSION,
                                        common.ages,
-                                       None, [macaroonbakery.LOGIN_OP])
+                                       None, [bakery.LOGIN_OP])
 
         # ts somehow sends the macaroon to fs which adds a third party caveat
         # to be discharged by bs.
@@ -62,25 +61,28 @@ class TestDischarge(unittest.TestCase):
         # client asks for a discharge macaroon for each third party caveat
         def get_discharge(cav, payload):
             self.assertEqual(cav.location, 'bs-loc')
-            return macaroonbakery.discharge(common.test_context, cav.caveat_id_bytes, payload,
-                                            bs.oven.key,
-                                            common.ThirdPartyStrcmpChecker(
-                                                'user==bob'),
-                                            bs.oven.locator)
+            return bakery.discharge(
+                common.test_context,
+                cav.caveat_id_bytes,
+                payload,
+                bs.oven.key,
+                common.ThirdPartyStrcmpChecker('user==bob'),
+                bs.oven.locator,
+            )
 
-        d = macaroonbakery.discharge_all(ts_macaroon, get_discharge)
+        d = bakery.discharge_all(ts_macaroon, get_discharge)
 
         ts.checker.auth([d]).allow(common.test_context,
-                                   [macaroonbakery.LOGIN_OP])
+                                   [bakery.LOGIN_OP])
 
     def test_discharge_with_version1_macaroon(self):
-        locator = macaroonbakery.ThirdPartyStore()
+        locator = bakery.ThirdPartyStore()
         bs = common.new_bakery('bs-loc', locator)
         ts = common.new_bakery('ts-loc', locator)
 
         # ts creates a old-version macaroon.
-        ts_macaroon = ts.oven.macaroon(macaroonbakery.BAKERY_V1, common.ages,
-                                       None, [macaroonbakery.LOGIN_OP])
+        ts_macaroon = ts.oven.macaroon(bakery.BAKERY_V1, common.ages,
+                                       None, [bakery.LOGIN_OP])
         ts_macaroon.add_caveat(checkers.Caveat(condition='something',
                                                location='bs-loc'),
                                ts.oven.key, ts.oven.locator)
@@ -93,16 +95,19 @@ class TestDischarge(unittest.TestCase):
                 cav.caveat_id_bytes.decode('utf-8')
             except UnicodeDecodeError:
                 self.fail('caveat id is not utf-8')
-            return macaroonbakery.discharge(common.test_context, cav.caveat_id_bytes, payload,
-                                            bs.oven.key,
-                                            common.ThirdPartyStrcmpChecker(
-                                                'something'),
-                                            bs.oven.locator)
+            return bakery.discharge(
+                common.test_context,
+                cav.caveat_id_bytes,
+                payload,
+                bs.oven.key,
+                common.ThirdPartyStrcmpChecker('something'),
+                bs.oven.locator,
+            )
 
-        d = macaroonbakery.discharge_all(ts_macaroon, get_discharge)
+        d = bakery.discharge_all(ts_macaroon, get_discharge)
 
         ts.checker.auth([d]).allow(common.test_context,
-                                   [macaroonbakery.LOGIN_OP])
+                                   [bakery.LOGIN_OP])
 
         for m in d:
             self.assertEqual(m.version, MACAROON_V1)
@@ -110,29 +115,31 @@ class TestDischarge(unittest.TestCase):
     def test_version1_macaroon_id(self):
         # In the version 1 bakery, macaroon ids were hex-encoded with a
         # hyphenated UUID suffix.
-        root_key_store = macaroonbakery.MemoryKeyStore()
-        b = macaroonbakery.Bakery(root_key_store=root_key_store,
-                                  identity_client=common.OneIdentity())
+        root_key_store = bakery.MemoryKeyStore()
+        b = bakery.Bakery(
+            root_key_store=root_key_store,
+            identity_client=common.OneIdentity(),
+        )
         key, id = root_key_store.root_key()
         root_key_store.get(id)
         m = Macaroon(key=key, version=MACAROON_V1, location='',
                      identifier=id + b'-deadl00f')
         b.checker.auth([[m]]).allow(common.test_context,
-                                    [macaroonbakery.LOGIN_OP])
+                                    [bakery.LOGIN_OP])
 
     def test_macaroon_paper_fig6_fails_without_discharges(self):
         ''' Runs a similar test as test_macaroon_paper_fig6 without the client
         discharging the third party caveats.
         '''
-        locator = macaroonbakery.ThirdPartyStore()
+        locator = bakery.ThirdPartyStore()
         ts = common.new_bakery('ts-loc', locator)
         fs = common.new_bakery('fs-loc', locator)
         common.new_bakery('as-loc', locator)
 
         # ts creates a macaroon.
-        ts_macaroon = ts.oven.macaroon(macaroonbakery.LATEST_BAKERY_VERSION,
+        ts_macaroon = ts.oven.macaroon(bakery.LATEST_BAKERY_VERSION,
                                        common.ages, None,
-                                       [macaroonbakery.LOGIN_OP])
+                                       [bakery.LOGIN_OP])
 
         # ts somehow sends the macaroon to fs which adds a third party
         # caveat to be discharged by as.
@@ -144,24 +151,24 @@ class TestDischarge(unittest.TestCase):
         try:
             ts.checker.auth([[ts_macaroon.macaroon]]).allow(
                 common.test_context,
-                macaroonbakery.LOGIN_OP
+                bakery.LOGIN_OP
             )
             self.fail('macaroon unmet should be raised')
-        except VerificationError:
+        except bakery.VerificationError:
             pass
 
     def test_macaroon_paper_fig6_fails_with_binding_on_tampered_sig(self):
         ''' Runs a similar test as test_macaroon_paper_fig6 with the discharge
         macaroon binding being done on a tampered signature.
         '''
-        locator = macaroonbakery.ThirdPartyStore()
+        locator = bakery.ThirdPartyStore()
         bs = common.new_bakery('bs-loc', locator)
         ts = common.new_bakery('ts-loc', locator)
 
         # ts creates a macaroon.
-        ts_macaroon = ts.oven.macaroon(macaroonbakery.LATEST_BAKERY_VERSION,
+        ts_macaroon = ts.oven.macaroon(bakery.LATEST_BAKERY_VERSION,
                                        common.ages, None,
-                                       [macaroonbakery.LOGIN_OP])
+                                       [bakery.LOGIN_OP])
         # ts somehow sends the macaroon to fs which adds a third party caveat
         # to be discharged by as.
         ts_macaroon.add_caveat(checkers.Caveat(condition='user==bob',
@@ -171,13 +178,16 @@ class TestDischarge(unittest.TestCase):
         # client asks for a discharge macaroon for each third party caveat
         def get_discharge(cav, payload):
             self.assertEqual(cav.location, 'bs-loc')
-            return macaroonbakery.discharge(common.test_context, cav.caveat_id_bytes, payload,
-                                            bs.oven.key,
-                                            common.ThirdPartyStrcmpChecker(
-                                                'user==bob'),
-                                            bs.oven.locator)
+            return bakery.discharge(
+                common.test_context,
+                cav.caveat_id_bytes,
+                payload,
+                bs.oven.key,
+                common.ThirdPartyStrcmpChecker('user==bob'),
+                bs.oven.locator,
+            )
 
-        d = macaroonbakery.discharge_all(ts_macaroon, get_discharge)
+        d = bakery.discharge_all(ts_macaroon, get_discharge)
         # client has all the discharge macaroons. For each discharge macaroon
         # bind it to our ts_macaroon and add it to our request.
         tampered_macaroon = Macaroon()
@@ -185,36 +195,39 @@ class TestDischarge(unittest.TestCase):
             d[i + 1] = tampered_macaroon.prepare_for_request(dm)
 
         # client makes request to ts.
-        with self.assertRaises(VerificationError) as exc:
+        with self.assertRaises(bakery.VerificationError) as exc:
             ts.checker.auth([d]).allow(common.test_context,
-                                       macaroonbakery.LOGIN_OP)
+                                       bakery.LOGIN_OP)
         self.assertEqual('verification failed: Signatures do not match',
                          exc.exception.args[0])
 
     def test_need_declared(self):
-        locator = macaroonbakery.ThirdPartyStore()
+        locator = bakery.ThirdPartyStore()
         first_party = common.new_bakery('first', locator)
         third_party = common.new_bakery('third', locator)
 
         # firstParty mints a macaroon with a third-party caveat addressed
         # to thirdParty with a need-declared caveat.
         m = first_party.oven.macaroon(
-            macaroonbakery.LATEST_BAKERY_VERSION, common.ages, [
+            bakery.LATEST_BAKERY_VERSION, common.ages, [
                 checkers.need_declared_caveat(
                     checkers.Caveat(location='third', condition='something'),
                     ['foo', 'bar']
                 )
-            ], [macaroonbakery.LOGIN_OP])
+            ], [bakery.LOGIN_OP])
 
         # The client asks for a discharge macaroon for each third party caveat.
         def get_discharge(cav, payload):
-            return macaroonbakery.discharge(common.test_context, cav.caveat_id_bytes, payload,
-                                            third_party.oven.key,
-                                            common.ThirdPartyStrcmpChecker(
-                                                'something'),
-                                            third_party.oven.locator)
+            return bakery.discharge(
+                common.test_context,
+                cav.caveat_id_bytes,
+                payload,
+                third_party.oven.key,
+                common.ThirdPartyStrcmpChecker('something'),
+                third_party.oven.locator,
+            )
 
-        d = macaroonbakery.discharge_all(m, get_discharge)
+        d = bakery.discharge_all(m, get_discharge)
 
         # The required declared attributes should have been added
         # to the discharge macaroons.
@@ -227,7 +240,7 @@ class TestDischarge(unittest.TestCase):
         # Make sure the macaroons actually check out correctly
         # when provided with the declared checker.
         ctx = checkers.context_with_declared(common.test_context, declared)
-        first_party.checker.auth([d]).allow(ctx, [macaroonbakery.LOGIN_OP])
+        first_party.checker.auth([d]).allow(ctx, [bakery.LOGIN_OP])
 
         # Try again when the third party does add a required declaration.
 
@@ -237,12 +250,16 @@ class TestDischarge(unittest.TestCase):
                 checkers.declared_caveat('foo', 'a'),
                 checkers.declared_caveat('arble', 'b')
             ])
-            return macaroonbakery.discharge(common.test_context, cav.caveat_id_bytes, payload,
-                                            third_party.oven.key,
-                                            checker,
-                                            third_party.oven.locator)
+            return bakery.discharge(
+                common.test_context,
+                cav.caveat_id_bytes,
+                payload,
+                third_party.oven.key,
+                checker,
+                third_party.oven.locator,
+            )
 
-        d = macaroonbakery.discharge_all(m, get_discharge)
+        d = bakery.discharge_all(m, get_discharge)
 
         # One attribute should have been added, the other was already there.
         declared = checkers.infer_declared(d, first_party.checker.namespace())
@@ -253,7 +270,7 @@ class TestDischarge(unittest.TestCase):
         })
 
         ctx = checkers.context_with_declared(common.test_context, declared)
-        first_party.checker.auth([d]).allow(ctx, [macaroonbakery.LOGIN_OP])
+        first_party.checker.auth([d]).allow(ctx, [bakery.LOGIN_OP])
 
         # Try again, but this time pretend a client is sneakily trying
         # to add another 'declared' attribute to alter the declarations.
@@ -265,13 +282,16 @@ class TestDischarge(unittest.TestCase):
             ])
 
             # Sneaky client adds a first party caveat.
-            m = macaroonbakery.discharge(common.test_context, cav.caveat_id_bytes, payload,
-                                         third_party.oven.key, checker,
-                                         third_party.oven.locator)
+            m = bakery.discharge(
+                common.test_context, cav.caveat_id_bytes,
+                payload,
+                third_party.oven.key, checker,
+                third_party.oven.locator,
+            )
             m.add_caveat(checkers.declared_caveat('foo', 'c'), None, None)
             return m
 
-        d = macaroonbakery.discharge_all(m, get_discharge)
+        d = bakery.discharge_all(m, get_discharge)
 
         declared = checkers.infer_declared(d, first_party.checker.namespace())
         self.assertEqual(declared, {
@@ -279,22 +299,22 @@ class TestDischarge(unittest.TestCase):
             'arble': 'b',
         })
 
-        with self.assertRaises(macaroonbakery.AuthInitError) as exc:
+        with self.assertRaises(bakery.AuthInitError) as exc:
             first_party.checker.auth([d]).allow(common.test_context,
-                                                macaroonbakery.LOGIN_OP)
+                                                bakery.LOGIN_OP)
         self.assertEqual('cannot authorize login macaroon: caveat '
                          '"declared foo a" not satisfied: got foo=null, '
                          'expected "a"', exc.exception.args[0])
 
     def test_discharge_two_need_declared(self):
-        locator = macaroonbakery.ThirdPartyStore()
+        locator = bakery.ThirdPartyStore()
         first_party = common.new_bakery('first', locator)
         third_party = common.new_bakery('third', locator)
 
         # first_party mints a macaroon with two third party caveats
         # with overlapping attributes.
         m = first_party.oven.macaroon(
-            macaroonbakery.LATEST_BAKERY_VERSION,
+            bakery.LATEST_BAKERY_VERSION,
             common.ages, [
                 checkers.need_declared_caveat(
                     checkers.Caveat(location='third', condition='x'),
@@ -302,13 +322,13 @@ class TestDischarge(unittest.TestCase):
                 checkers.need_declared_caveat(
                     checkers.Caveat(location='third', condition='y'),
                     ['bar', 'baz']),
-            ], [macaroonbakery.LOGIN_OP])
+            ], [bakery.LOGIN_OP])
 
         # The client asks for a discharge macaroon for each third party caveat.
         # Since no declarations are added by the discharger,
 
         def get_discharge(cav, payload):
-            return macaroonbakery.discharge(
+            return bakery.discharge(
                 common.test_context,
                 cav.caveat_id_bytes,
                 payload,
@@ -317,7 +337,7 @@ class TestDischarge(unittest.TestCase):
                 third_party.oven.locator,
             )
 
-        d = macaroonbakery.discharge_all(m, get_discharge)
+        d = bakery.discharge_all(m, get_discharge)
         declared = checkers.infer_declared(d, first_party.checker.namespace())
         self.assertEqual(declared, {
             'foo': '',
@@ -325,12 +345,12 @@ class TestDischarge(unittest.TestCase):
             'baz': '',
         })
         ctx = checkers.context_with_declared(common.test_context, declared)
-        first_party.checker.auth([d]).allow(ctx, [macaroonbakery.LOGIN_OP])
+        first_party.checker.auth([d]).allow(ctx, [bakery.LOGIN_OP])
 
         # If they return conflicting values, the discharge fails.
         # The client asks for a discharge macaroon for each third party caveat.
         # Since no declarations are added by the discharger,
-        class ThirdPartyCaveatCheckerF(macaroonbakery.ThirdPartyCaveatChecker):
+        class ThirdPartyCaveatCheckerF(bakery.ThirdPartyCaveatChecker):
             def check_third_party_caveat(self, ctx, cav_info):
                 if cav_info.condition == b'x':
                     return [checkers.declared_caveat('foo', 'fooval1')]
@@ -342,7 +362,7 @@ class TestDischarge(unittest.TestCase):
                 raise common.ThirdPartyCaveatCheckFailed('not matched')
 
         def get_discharge(cav, payload):
-            return macaroonbakery.discharge(
+            return bakery.discharge(
                 common.test_context,
                 cav.caveat_id_bytes,
                 payload,
@@ -351,38 +371,38 @@ class TestDischarge(unittest.TestCase):
                 third_party.oven.locator,
             )
 
-        d = macaroonbakery.discharge_all(m, get_discharge)
+        d = bakery.discharge_all(m, get_discharge)
 
         declared = checkers.infer_declared(d, first_party.checker.namespace())
         self.assertEqual(declared, {
             'bar': '',
             'baz': 'bazval',
         })
-        with self.assertRaises(macaroonbakery.AuthInitError) as exc:
+        with self.assertRaises(bakery.AuthInitError) as exc:
             first_party.checker.auth([d]).allow(common.test_context,
-                                                macaroonbakery.LOGIN_OP)
+                                                bakery.LOGIN_OP)
         self.assertEqual('cannot authorize login macaroon: caveat "declared '
                          'foo fooval1" not satisfied: got foo=null, expected '
                          '"fooval1"', exc.exception.args[0])
 
     def test_discharge_macaroon_cannot_be_used_as_normal_macaroon(self):
-        locator = macaroonbakery.ThirdPartyStore()
+        locator = bakery.ThirdPartyStore()
         first_party = common.new_bakery('first', locator)
         third_party = common.new_bakery('third', locator)
 
         # First party mints a macaroon with a 3rd party caveat.
-        m = first_party.oven.macaroon(macaroonbakery.LATEST_BAKERY_VERSION,
+        m = first_party.oven.macaroon(bakery.LATEST_BAKERY_VERSION,
                                       common.ages, [
                                           checkers.Caveat(location='third',
                                                           condition='true')],
-                                      [macaroonbakery.LOGIN_OP])
+                                      [bakery.LOGIN_OP])
 
         # Acquire the discharge macaroon, but don't bind it to the original.
         class M:
             unbound = None
 
         def get_discharge(cav, payload):
-            m = macaroonbakery.discharge(
+            m = bakery.discharge(
                 common.test_context,
                 cav.caveat_id_bytes,
                 payload,
@@ -393,18 +413,18 @@ class TestDischarge(unittest.TestCase):
             M.unbound = m.macaroon.copy()
             return m
 
-        macaroonbakery.discharge_all(m, get_discharge)
+        bakery.discharge_all(m, get_discharge)
         self.assertIsNotNone(M.unbound)
 
         # Make sure it cannot be used as a normal macaroon in the third party.
-        with self.assertRaises(macaroonbakery.VerificationError) as exc:
+        with self.assertRaises(bakery.VerificationError) as exc:
             third_party.checker.auth([[M.unbound]]).allow(
-                common.test_context, [macaroonbakery.LOGIN_OP])
+                common.test_context, [bakery.LOGIN_OP])
         self.assertEqual('no operations found in macaroon',
                          exc.exception.args[0])
 
     def test_third_party_discharge_macaroon_ids_are_small(self):
-        locator = macaroonbakery.ThirdPartyStore()
+        locator = bakery.ThirdPartyStore()
         bakeries = {
             'ts-loc': common.new_bakery('ts-loc', locator),
             'as1-loc': common.new_bakery('as1-loc', locator),
@@ -412,14 +432,14 @@ class TestDischarge(unittest.TestCase):
         }
         ts = bakeries['ts-loc']
 
-        ts_macaroon = ts.oven.macaroon(macaroonbakery.LATEST_BAKERY_VERSION,
+        ts_macaroon = ts.oven.macaroon(bakery.LATEST_BAKERY_VERSION,
                                        common.ages,
-                                       None, [macaroonbakery.LOGIN_OP])
+                                       None, [bakery.LOGIN_OP])
         ts_macaroon.add_caveat(checkers.Caveat(condition='something',
                                                location='as1-loc'),
                                ts.oven.key, ts.oven.locator)
 
-        class ThirdPartyCaveatCheckerF(macaroonbakery.ThirdPartyCaveatChecker):
+        class ThirdPartyCaveatCheckerF(bakery.ThirdPartyCaveatChecker):
             def __init__(self, loc):
                 self._loc = loc
 
@@ -434,7 +454,7 @@ class TestDischarge(unittest.TestCase):
 
         def get_discharge(cav, payload):
             oven = bakeries[cav.location].oven
-            return macaroonbakery.discharge(
+            return bakery.discharge(
                 common.test_context,
                 cav.caveat_id_bytes,
                 payload,
@@ -443,9 +463,9 @@ class TestDischarge(unittest.TestCase):
                 oven.locator,
             )
 
-        d = macaroonbakery.discharge_all(ts_macaroon, get_discharge)
+        d = bakery.discharge_all(ts_macaroon, get_discharge)
         ts.checker.auth([d]).allow(common.test_context,
-                                   [macaroonbakery.LOGIN_OP])
+                                   [bakery.LOGIN_OP])
 
         for i, m in enumerate(d):
             for j, cav in enumerate(m.caveats):

--- a/macaroonbakery/tests/test_oven.py
+++ b/macaroonbakery/tests/test_oven.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 import copy
 from datetime import datetime, timedelta
 
-import macaroonbakery
+import macaroonbakery as bakery
 
 EPOCH = datetime(1900, 11, 17, 19, 00, 13, 0, None)
 AGES = EPOCH + timedelta(days=10)
@@ -15,111 +15,110 @@ class TestOven(TestCase):
     def test_canonical_ops(self):
         canonical_ops_tests = (
             ('empty array', [], []),
-            ('one element', [macaroonbakery.Op('a', 'a')],
-             [macaroonbakery.Op('a', 'a')]),
+            ('one element', [bakery.Op('a', 'a')],
+             [bakery.Op('a', 'a')]),
             ('all in order',
-             [macaroonbakery.Op('a', 'a'), macaroonbakery.Op('a', 'b'),
-              macaroonbakery.Op('c', 'c')],
-             [macaroonbakery.Op('a', 'a'), macaroonbakery.Op('a', 'b'),
-              macaroonbakery.Op('c', 'c')]),
+             [bakery.Op('a', 'a'), bakery.Op('a', 'b'),
+              bakery.Op('c', 'c')],
+             [bakery.Op('a', 'a'), bakery.Op('a', 'b'),
+              bakery.Op('c', 'c')]),
             ('out of order',
-             [macaroonbakery.Op('c', 'c'), macaroonbakery.Op('a', 'b'),
-              macaroonbakery.Op('a', 'a')],
-             [macaroonbakery.Op('a', 'a'), macaroonbakery.Op('a', 'b'),
-              macaroonbakery.Op('c', 'c')]),
+             [bakery.Op('c', 'c'), bakery.Op('a', 'b'),
+              bakery.Op('a', 'a')],
+             [bakery.Op('a', 'a'), bakery.Op('a', 'b'),
+              bakery.Op('c', 'c')]),
             ('with duplicates',
-             [macaroonbakery.Op('c', 'c'), macaroonbakery.Op('a', 'b'),
-              macaroonbakery.Op('a', 'a'), macaroonbakery.Op('c', 'a'),
-              macaroonbakery.Op('c', 'b'), macaroonbakery.Op('c', 'c'),
-              macaroonbakery.Op('a', 'a')],
-             [macaroonbakery.Op('a', 'a'), macaroonbakery.Op('a', 'b'),
-              macaroonbakery.Op('c', 'a'), macaroonbakery.Op('c', 'b'),
-              macaroonbakery.Op('c', 'c')]),
+             [bakery.Op('c', 'c'), bakery.Op('a', 'b'),
+              bakery.Op('a', 'a'), bakery.Op('c', 'a'),
+              bakery.Op('c', 'b'), bakery.Op('c', 'c'),
+              bakery.Op('a', 'a')],
+             [bakery.Op('a', 'a'), bakery.Op('a', 'b'),
+              bakery.Op('c', 'a'), bakery.Op('c', 'b'),
+              bakery.Op('c', 'c')]),
             ('make sure we\'ve got the fields right',
-             [macaroonbakery.Op(entity='read', action='two'),
-              macaroonbakery.Op(entity='read', action='one'),
-              macaroonbakery.Op(entity='write', action='one')],
-             [macaroonbakery.Op(entity='read', action='one'),
-              macaroonbakery.Op(entity='read', action='two'),
-              macaroonbakery.Op(entity='write', action='one')])
+             [bakery.Op(entity='read', action='two'),
+              bakery.Op(entity='read', action='one'),
+              bakery.Op(entity='write', action='one')],
+             [bakery.Op(entity='read', action='one'),
+              bakery.Op(entity='read', action='two'),
+              bakery.Op(entity='write', action='one')])
         )
         for about, ops, expected in canonical_ops_tests:
             new_ops = copy.copy(ops)
-            canonical_ops = macaroonbakery.canonical_ops(new_ops)
+            canonical_ops = bakery.canonical_ops(new_ops)
             self.assertEquals(canonical_ops, expected)
             # Verify that the original array isn't changed.
             self.assertEquals(new_ops, ops)
 
     def test_multiple_ops(self):
-        test_oven = macaroonbakery.Oven(
-            ops_store=macaroonbakery.MemoryOpsStore())
-        ops = [macaroonbakery.Op('one', 'read'),
-               macaroonbakery.Op('one', 'write'),
-               macaroonbakery.Op('two', 'read')]
-        m = test_oven.macaroon(macaroonbakery.LATEST_BAKERY_VERSION, AGES,
+        test_oven = bakery.Oven(
+            ops_store=bakery.MemoryOpsStore())
+        ops = [bakery.Op('one', 'read'),
+               bakery.Op('one', 'write'),
+               bakery.Op('two', 'read')]
+        m = test_oven.macaroon(bakery.LATEST_BAKERY_VERSION, AGES,
                                None, ops)
         got_ops, conds = test_oven.macaroon_ops([m.macaroon])
         self.assertEquals(len(conds), 1)  # time-before caveat.
-        self.assertEquals(macaroonbakery.canonical_ops(got_ops), ops)
+        self.assertEquals(bakery.canonical_ops(got_ops), ops)
 
     def test_multiple_ops_in_id(self):
-        test_oven = macaroonbakery.Oven()
-        ops = [macaroonbakery.Op('one', 'read'),
-               macaroonbakery.Op('one', 'write'),
-               macaroonbakery.Op('two', 'read')]
-        m = test_oven.macaroon(macaroonbakery.LATEST_BAKERY_VERSION, AGES,
+        test_oven = bakery.Oven()
+        ops = [bakery.Op('one', 'read'),
+               bakery.Op('one', 'write'),
+               bakery.Op('two', 'read')]
+        m = test_oven.macaroon(bakery.LATEST_BAKERY_VERSION, AGES,
                                None, ops)
         got_ops, conds = test_oven.macaroon_ops([m.macaroon])
         self.assertEquals(len(conds), 1)  # time-before caveat.
-        self.assertEquals(macaroonbakery.canonical_ops(got_ops), ops)
+        self.assertEquals(bakery.canonical_ops(got_ops), ops)
 
     def test_multiple_ops_in_id_with_version1(self):
-        test_oven = macaroonbakery.Oven()
-        ops = [macaroonbakery.Op('one', 'read'),
-               macaroonbakery.Op('one', 'write'),
-               macaroonbakery.Op('two', 'read')]
-        m = test_oven.macaroon(macaroonbakery.BAKERY_V1, AGES, None, ops)
+        test_oven = bakery.Oven()
+        ops = [bakery.Op('one', 'read'),
+               bakery.Op('one', 'write'),
+               bakery.Op('two', 'read')]
+        m = test_oven.macaroon(bakery.BAKERY_V1, AGES, None, ops)
         got_ops, conds = test_oven.macaroon_ops([m.macaroon])
         self.assertEquals(len(conds), 1)  # time-before caveat.
-        self.assertEquals(macaroonbakery.canonical_ops(got_ops), ops)
+        self.assertEquals(bakery.canonical_ops(got_ops), ops)
 
     def test_huge_number_of_ops_gives_small_macaroon(self):
-        test_oven = macaroonbakery.Oven(
-            ops_store=macaroonbakery.MemoryOpsStore())
+        test_oven = bakery.Oven(
+            ops_store=bakery.MemoryOpsStore())
         ops = []
         for i in range(30000):
-            ops.append(macaroonbakery.Op(entity='entity{}'.format(i),
-                                         action='action{}'.format(i)))
+            ops.append(bakery.Op(entity='entity' + str(i), action='action' + str(i)))
 
-        m = test_oven.macaroon(macaroonbakery.LATEST_BAKERY_VERSION, AGES,
+        m = test_oven.macaroon(bakery.LATEST_BAKERY_VERSION, AGES,
                                None, ops)
         got_ops, conds = test_oven.macaroon_ops([m.macaroon])
         self.assertEquals(len(conds), 1)  # time-before caveat.
-        self.assertEquals(macaroonbakery.canonical_ops(got_ops),
-                          macaroonbakery.canonical_ops(ops))
+        self.assertEquals(bakery.canonical_ops(got_ops),
+                          bakery.canonical_ops(ops))
 
         data = m.serialize_json()
         self.assertLess(len(data), 300)
 
     def test_ops_stored_only_once(self):
-        st = macaroonbakery.MemoryOpsStore()
-        test_oven = macaroonbakery.Oven(ops_store=st)
+        st = bakery.MemoryOpsStore()
+        test_oven = bakery.Oven(ops_store=st)
 
-        ops = [macaroonbakery.Op('one', 'read'),
-               macaroonbakery.Op('one', 'write'),
-               macaroonbakery.Op('two', 'read')]
+        ops = [bakery.Op('one', 'read'),
+               bakery.Op('one', 'write'),
+               bakery.Op('two', 'read')]
 
-        m = test_oven.macaroon(macaroonbakery.LATEST_BAKERY_VERSION, AGES,
+        m = test_oven.macaroon(bakery.LATEST_BAKERY_VERSION, AGES,
                                None, ops)
         got_ops, conds = test_oven.macaroon_ops([m.macaroon])
-        self.assertEquals(macaroonbakery.canonical_ops(got_ops),
-                          macaroonbakery.canonical_ops(ops))
+        self.assertEquals(bakery.canonical_ops(got_ops),
+                          bakery.canonical_ops(ops))
 
         # Make another macaroon containing the same ops in a different order.
-        ops = [macaroonbakery.Op('one', 'write'),
-               macaroonbakery.Op('one', 'read'),
-               macaroonbakery.Op('one', 'read'),
-               macaroonbakery.Op('two', 'read')]
-        test_oven.macaroon(macaroonbakery.LATEST_BAKERY_VERSION, AGES, None,
+        ops = [bakery.Op('one', 'write'),
+               bakery.Op('one', 'read'),
+               bakery.Op('one', 'read'),
+               bakery.Op('two', 'read')]
+        test_oven.macaroon(bakery.LATEST_BAKERY_VERSION, AGES, None,
                            ops)
         self.assertEquals(len(st._store), 1)

--- a/macaroonbakery/tests/test_store.py
+++ b/macaroonbakery/tests/test_store.py
@@ -2,12 +2,12 @@
 # Licensed under the LGPLv3, see LICENCE file for details.
 from unittest import TestCase
 
-import macaroonbakery
+import macaroonbakery as bakery
 
 
 class TestOven(TestCase):
     def test_mem_store(self):
-        st = macaroonbakery.MemoryKeyStore()
+        st = bakery.MemoryKeyStore()
 
         key, id = st.root_key()
         self.assertEqual(len(key), 24)


### PR DESCRIPTION
Use the "bakery" identifier for the macaroonbakery package everywhere.

Use all-args-on-separate-lines style when we want to split
a function onto multiple lines, as it's less sensitive to
automated changes that change the length of the initial
function call.

Split multiple import-from statements across multiple lines
and sort the imported identifiers.