### PR TITLE
httpbakery: add Client.handle_error method

### DIFF
--- a/macaroonbakery/httpbakery/error.py
+++ b/macaroonbakery/httpbakery/error.py
@@ -178,7 +178,7 @@ class ErrorInfo(
             return None
         macaroon = serialized.get('Macaroon')
         if macaroon is not None:
-            macaroon = bakery.Macaroon.deserialize_json(macaroon)
+            macaroon = bakery.Macaroon.from_dict(macaroon)
         path = serialized.get('MacaroonPath')
         cookie_name_suffix = serialized.get('CookieNameSuffix')
         visit_url = serialized.get('VisitURL')

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist = lint, py27, py35, docs
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/macaroonbakery
 # drop into debugger with: nosetests --pdb
+# coverage with  --with-coverage --cover-inclusive --cover-html
 commands =
     nosetests
 deps =


### PR DESCRIPTION
This enables the client discharge logic to be used
for non-HTTP requests too.