### PR TITLE
Lowering the protobuf and requests deps.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,11 @@ with open('README.rst') as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    'requests>=2.18.4,<3.0',
+    'requests>=2.18.1,<3.0',
     'PyNaCl>=1.1.2,<2.0',
     'pymacaroons>=0.12.0,<1.0',
     'six>=1.11.0,<2.0',
-    'protobuf>=3.4.0,<4.0',
+    'protobuf>=3.0.0,<4.0',
     'pyRFC3339>=1.0,<2.0',
     'pytz>=2017.2,<2018.0'
 ]


### PR DESCRIPTION
Lowering the protobuf and requests deps in order to facilitate the inclusion of py-macaroon-bakery in Debian and Bionic.

Tox runs fine. 