### PR TITLE
Isolate client tests from any HTTP proxy

### DIFF
--- a/macaroonbakery/tests/test_client.py
+++ b/macaroonbakery/tests/test_client.py
@@ -35,6 +35,7 @@ class TestClient(TestWithFixtures):
         # http_proxy would cause requests to talk to the proxy, which is
         # unlikely to know how to talk to the test server.
         self.useFixture(EnvironmentVariable('http_proxy'))
+        self.useFixture(EnvironmentVariable('HTTP_PROXY'))
 
     def test_single_service_first_party(self):
         b = new_bakery('loc', None, None)

--- a/macaroonbakery/tests/test_client.py
+++ b/macaroonbakery/tests/test_client.py
@@ -3,6 +3,7 @@
 import base64
 import datetime
 import json
+import os
 import threading
 from unittest import TestCase
 
@@ -27,6 +28,12 @@ TEST_OP = bakery.Op(entity='test', action='test')
 
 
 class TestClient(TestCase):
+    def setUp(self):
+        super(TestClient, self).setUp()
+        # http_proxy would cause requests to talk to the proxy, which is
+        # unlikely to know how to talk to the test server.
+        os.environ.pop('http_proxy', None)
+
     def test_single_service_first_party(self):
         b = new_bakery('loc', None, None)
 

--- a/macaroonbakery/tests/test_client.py
+++ b/macaroonbakery/tests/test_client.py
@@ -3,9 +3,7 @@
 import base64
 import datetime
 import json
-import os
 import threading
-from unittest import TestCase
 
 import macaroonbakery.bakery as bakery
 import macaroonbakery.checkers as checkers
@@ -14,6 +12,10 @@ import pymacaroons
 import requests
 import macaroonbakery._utils as utils
 
+from fixtures import (
+    EnvironmentVariable,
+    TestWithFixtures,
+)
 from httmock import HTTMock, urlmatch
 from six.moves.urllib.parse import parse_qs
 from six.moves.urllib.request import Request
@@ -27,12 +29,12 @@ AGES = datetime.datetime.utcnow() + datetime.timedelta(days=1)
 TEST_OP = bakery.Op(entity='test', action='test')
 
 
-class TestClient(TestCase):
+class TestClient(TestWithFixtures):
     def setUp(self):
         super(TestClient, self).setUp()
         # http_proxy would cause requests to talk to the proxy, which is
         # unlikely to know how to talk to the test server.
-        os.environ.pop('http_proxy', None)
+        self.useFixture(EnvironmentVariable('http_proxy'))
 
     def test_single_service_first_party(self):
         b = new_bakery('loc', None, None)

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ requirements = [
 
 test_requirements = [
     'tox',
+    'fixtures',
     'httmock==1.2.5',
 ]
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,15 @@
 # Licensed under the LGPLv3, see LICENCE file for details.
 
 coverage==3.7.1
+extras==1.0.0
+fixtures==3.0.0
 flake8==2.4.0
+httmock==1.2.5
+linecache2==1.0.0
 mock==1.0.1
 nose==1.3.6
-httmock==1.2.5
+pbr==3.1.1
+python-mimeparse==1.6.0
+testtools==2.3.0
+traceback2==1.4.0
+unittest2==1.1.0


### PR DESCRIPTION
Debian's Python packaging tools set http_proxy to a non-existent proxy
to help flush out packages that try to talk to the network during build,
but these tests could previously fail in more normal development
environments too.