### PR TITLE
only check first-party caveats in expiry_time

### DIFF
--- a/macaroonbakery/checkers/time.py
+++ b/macaroonbakery/checkers/time.py
@@ -54,6 +54,8 @@ def expiry_time(ns, cavs):
         prefix, COND_TIME_BEFORE)
     t = None
     for cav in cavs:
+        if not cav.first_party():
+            continue
         cav = cav.caveat_id_bytes.decode('utf-8')
         name, rest = parse_caveat(cav)
         if name != time_before_cond:

--- a/macaroonbakery/tests/test_time.py
+++ b/macaroonbakery/tests/test_time.py
@@ -122,6 +122,13 @@ class TestExpireTime(TestCase):
                                                test.macaroons)
             self.assertEqual(t, test.expectTime)
 
+    def test_macaroons_expire_time_skips_third_party(self):
+        m1 = newMacaroon([checkers.time_before_caveat(t1).condition])
+        m2 = newMacaroon()
+        m2.add_third_party_caveat('https://example.com', 'a-key', '123')
+        t = checkers.macaroons_expiry_time(checkers.Namespace(), [m1, m2])
+        self.assertEqual(t1, t)
+
 
 def newMacaroon(conds=[]):
     m = Macaroon(key='key', version=2)


### PR DESCRIPTION
Don't try to decode third-party caveats