### PR TITLE
auto-sort all imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,3 +96,11 @@ test: setup
 	@$(DEVENV)/bin/nosetests \
 		--verbosity 2 --with-coverage --cover-erase \
 		--cover-package macaroonbakery
+
+.PHONY: isort
+isort:
+	isort \
+		--trailing-comma \
+		--recursive \
+		--multi-line 3 \
+		`find macaroonbakery -name '*.py' | grep -v 'internal/id_pb2\.py'`

--- a/macaroonbakery/authorizer.py
+++ b/macaroonbakery/authorizer.py
@@ -4,7 +4,6 @@ import abc
 
 import macaroonbakery as bakery
 
-
 # EVERYONE is recognized by ACLAuthorizer as the name of a
 # group that has everyone in it.
 EVERYONE = 'everyone'

--- a/macaroonbakery/bakery.py
+++ b/macaroonbakery/bakery.py
@@ -1,10 +1,10 @@
 # Copyright 2017 Canonical Ltd.
 # Licensed under the LGPLv3, see LICENCE file for details.
 
+from macaroonbakery.authorizer import ClosedAuthorizer
+from macaroonbakery.checker import Checker
 from macaroonbakery.checkers import checkers
 from macaroonbakery.oven import Oven
-from macaroonbakery.checker import Checker
-from macaroonbakery.authorizer import ClosedAuthorizer
 
 
 class Bakery(object):

--- a/macaroonbakery/checker.py
+++ b/macaroonbakery/checker.py
@@ -3,11 +3,9 @@
 from collections import namedtuple
 from threading import Lock
 
-
-import pyrfc3339
-
 import macaroonbakery as bakery
 import macaroonbakery.checkers as checkers
+import pyrfc3339
 
 
 class Op(namedtuple('Op', 'entity, action')):

--- a/macaroonbakery/checkers/caveat.py
+++ b/macaroonbakery/checkers/caveat.py
@@ -3,10 +3,13 @@
 import collections
 
 import pyrfc3339
-
 from macaroonbakery.checkers.conditions import (
-    STD_NAMESPACE, COND_TIME_BEFORE, COND_ERROR, COND_DENY, COND_ALLOW,
-    COND_DECLARED
+    COND_ALLOW,
+    COND_DECLARED,
+    COND_DENY,
+    COND_ERROR,
+    COND_TIME_BEFORE,
+    STD_NAMESPACE,
 )
 
 

--- a/macaroonbakery/checkers/checkers.py
+++ b/macaroonbakery/checkers/checkers.py
@@ -6,16 +6,19 @@ from datetime import datetime
 
 import pyrfc3339
 import pytz
-
-from macaroonbakery.checkers.declared import DECLARED_KEY
-from macaroonbakery.checkers.time import TIME_KEY
-from macaroonbakery.checkers.operation import OP_KEY
-from macaroonbakery.checkers.namespace import Namespace
 from macaroonbakery.checkers.caveat import parse_caveat
 from macaroonbakery.checkers.conditions import (
-    STD_NAMESPACE, COND_DECLARED, COND_ALLOW, COND_DENY, COND_ERROR,
-    COND_TIME_BEFORE
+    COND_ALLOW,
+    COND_DECLARED,
+    COND_DENY,
+    COND_ERROR,
+    COND_TIME_BEFORE,
+    STD_NAMESPACE,
 )
+from macaroonbakery.checkers.declared import DECLARED_KEY
+from macaroonbakery.checkers.namespace import Namespace
+from macaroonbakery.checkers.operation import OP_KEY
+from macaroonbakery.checkers.time import TIME_KEY
 from macaroonbakery.checkers.utils import condition_with_prefix
 
 

--- a/macaroonbakery/checkers/declared.py
+++ b/macaroonbakery/checkers/declared.py
@@ -1,11 +1,13 @@
 # Copyright 2017 Canonical Ltd.
 # Licensed under the LGPLv3, see LICENCE file for details.
-from macaroonbakery.checkers.namespace import Namespace
-from macaroonbakery.checkers.caveat import parse_caveat, Caveat, error_caveat
-from macaroonbakery.checkers.conditions import (
-    COND_DECLARED, COND_NEED_DECLARED, STD_NAMESPACE
-)
 from macaroonbakery.checkers.auth_context import ContextKey
+from macaroonbakery.checkers.caveat import Caveat, error_caveat, parse_caveat
+from macaroonbakery.checkers.conditions import (
+    COND_DECLARED,
+    COND_NEED_DECLARED,
+    STD_NAMESPACE,
+)
+from macaroonbakery.checkers.namespace import Namespace
 
 DECLARED_KEY = ContextKey('declared-key')
 

--- a/macaroonbakery/checkers/namespace.py
+++ b/macaroonbakery/checkers/namespace.py
@@ -2,8 +2,8 @@
 # Licensed under the LGPLv3, see LICENCE file for details.
 import collections
 
-from macaroonbakery.checkers.utils import condition_with_prefix
 from macaroonbakery.checkers.caveat import error_caveat
+from macaroonbakery.checkers.utils import condition_with_prefix
 
 
 class Namespace:

--- a/macaroonbakery/checkers/time.py
+++ b/macaroonbakery/checkers/time.py
@@ -2,12 +2,10 @@
 # Licensed under the LGPLv3, see LICENCE file for details.
 
 import pyrfc3339
-
 from macaroonbakery.checkers.auth_context import ContextKey
+from macaroonbakery.checkers.caveat import parse_caveat
 from macaroonbakery.checkers.conditions import COND_TIME_BEFORE, STD_NAMESPACE
 from macaroonbakery.checkers.utils import condition_with_prefix
-from macaroonbakery.checkers.caveat import parse_caveat
-
 
 TIME_KEY = ContextKey('time-key')
 

--- a/macaroonbakery/codec.py
+++ b/macaroonbakery/codec.py
@@ -3,11 +3,10 @@
 import base64
 import json
 
-import six
-import nacl.public
-
 import macaroonbakery as bakery
 import macaroonbakery.checkers as checkers
+import nacl.public
+import six
 
 _PUBLIC_KEY_PREFIX_LEN = 4
 _KEY_LEN = 32

--- a/macaroonbakery/httpbakery/browser.py
+++ b/macaroonbakery/httpbakery/browser.py
@@ -2,15 +2,18 @@
 # Licensed under the LGPLv3, see LICENCE file for details.
 import base64
 from collections import namedtuple
-import requests
-from six.moves.urllib.parse import urljoin
 
-from macaroonbakery.utils import visit_page_with_browser
-from macaroonbakery.httpbakery.interactor import (
-    Interactor, LegacyInteractor, WEB_BROWSER_INTERACTION_KIND,
-    DischargeToken
-)
+import requests
 from macaroonbakery.httpbakery.error import InteractionError
+from macaroonbakery.httpbakery.interactor import (
+    WEB_BROWSER_INTERACTION_KIND,
+    DischargeToken,
+    Interactor,
+    LegacyInteractor,
+)
+from macaroonbakery.utils import visit_page_with_browser
+
+from six.moves.urllib.parse import urljoin
 
 
 class WebBrowserInteractor(Interactor, LegacyInteractor):

--- a/macaroonbakery/httpbakery/client.py
+++ b/macaroonbakery/httpbakery/client.py
@@ -9,14 +9,19 @@ import macaroonbakery.checkers as checkers
 import requests
 from macaroonbakery import utils
 from macaroonbakery.httpbakery.browser import WebBrowserInteractor
-from macaroonbakery.httpbakery.error import (BAKERY_PROTOCOL_HEADER,
-                                             ERR_DISCHARGE_REQUIRED,
-                                             ERR_INTERACTION_REQUIRED,
-                                             DischargeError, Error,
-                                             InteractionError,
-                                             InteractionMethodNotFound)
-from macaroonbakery.httpbakery.interactor import (WEB_BROWSER_INTERACTION_KIND,
-                                                  LegacyInteractor)
+from macaroonbakery.httpbakery.error import (
+    BAKERY_PROTOCOL_HEADER,
+    ERR_DISCHARGE_REQUIRED,
+    ERR_INTERACTION_REQUIRED,
+    DischargeError,
+    Error,
+    InteractionError,
+    InteractionMethodNotFound,
+)
+from macaroonbakery.httpbakery.interactor import (
+    WEB_BROWSER_INTERACTION_KIND,
+    LegacyInteractor,
+)
 
 from six.moves.http_cookies import SimpleCookie
 from six.moves.urllib.parse import urljoin

--- a/macaroonbakery/httpbakery/discharge.py
+++ b/macaroonbakery/httpbakery/discharge.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Canonical Ltd.
 # Licensed under the LGPLv3, see LICENCE file for details.
-import macaroonbakery.utils as utils
 import macaroonbakery as bakery
+import macaroonbakery.utils as utils
 
 
 def discharge(ctx, content, key, locator, checker):

--- a/macaroonbakery/httpbakery/error.py
+++ b/macaroonbakery/httpbakery/error.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Canonical Ltd.
 # Licensed under the LGPLv3, see LICENCE file for details.
-from collections import namedtuple
 import json
+from collections import namedtuple
 
 import macaroonbakery as bakery
 

--- a/macaroonbakery/httpbakery/keyring.py
+++ b/macaroonbakery/httpbakery/keyring.py
@@ -1,10 +1,10 @@
 # Copyright 2017 Canonical Ltd.
 # Licensed under the LGPLv3, see LICENCE file for details.
-from six.moves.urllib.parse import urlparse
-import requests
-
 import macaroonbakery as bakery
+import requests
 from macaroonbakery.httpbakery.error import BAKERY_PROTOCOL_HEADER
+
+from six.moves.urllib.parse import urlparse
 
 
 class ThirdPartyLocator(bakery.ThirdPartyLocator):

--- a/macaroonbakery/macaroon.py
+++ b/macaroonbakery/macaroon.py
@@ -6,13 +6,11 @@ import json
 import logging
 import os
 
-import pymacaroons
-from pymacaroons.serializers import json_serializer
-
 import macaroonbakery as bakery
 import macaroonbakery.checkers as checkers
+import pymacaroons
 from macaroonbakery import utils
-
+from pymacaroons.serializers import json_serializer
 
 log = logging.getLogger(__name__)
 

--- a/macaroonbakery/oven.py
+++ b/macaroonbakery/oven.py
@@ -7,16 +7,16 @@ import itertools
 import os
 
 import google
-from pymacaroons import MACAROON_V2, Verifier
-from pymacaroons.exceptions import (
-    MacaroonUnmetCaveatException, MacaroonInvalidSignatureException
-)
-import six
-
 import macaroonbakery as bakery
 import macaroonbakery.checkers as checkers
+import six
 from macaroonbakery import utils
 from macaroonbakery.internal import id_pb2
+from pymacaroons import MACAROON_V2, Verifier
+from pymacaroons.exceptions import (
+    MacaroonInvalidSignatureException,
+    MacaroonUnmetCaveatException,
+)
 
 
 class Oven:

--- a/macaroonbakery/tests/common.py
+++ b/macaroonbakery/tests/common.py
@@ -2,10 +2,9 @@
 # Licensed under the LGPLv3, see LICENCE file for details.
 from datetime import datetime, timedelta
 
-import pytz
-
 import macaroonbakery as bakery
 import macaroonbakery.checkers as checkers
+import pytz
 
 
 class _StoppedClock(object):

--- a/macaroonbakery/tests/test_checker.py
+++ b/macaroonbakery/tests/test_checker.py
@@ -1,17 +1,16 @@
 # Copyright 2017 Canonical Ltd.
 # Licensed under the LGPLv3, see LICENCE file for details.
 import base64
-from collections import namedtuple
 import json
-from unittest import TestCase
+from collections import namedtuple
 from datetime import timedelta
-
-from pymacaroons.verifier import Verifier, FirstPartyCaveatVerifierDelegate
-import pymacaroons
+from unittest import TestCase
 
 import macaroonbakery as bakery
 import macaroonbakery.checkers as checkers
-from macaroonbakery.tests.common import test_context, epoch, test_checker
+import pymacaroons
+from macaroonbakery.tests.common import epoch, test_checker, test_context
+from pymacaroons.verifier import FirstPartyCaveatVerifierDelegate, Verifier
 
 
 class TestChecker(TestCase):

--- a/macaroonbakery/tests/test_checkers.py
+++ b/macaroonbakery/tests/test_checkers.py
@@ -3,11 +3,10 @@
 from datetime import datetime, timedelta
 from unittest import TestCase
 
-import six
-import pytz
-from pymacaroons import Macaroon, MACAROON_V2
-
 import macaroonbakery.checkers as checkers
+import pytz
+import six
+from pymacaroons import MACAROON_V2, Macaroon
 
 # A frozen time for the tests.
 NOW = datetime(

--- a/macaroonbakery/tests/test_client.py
+++ b/macaroonbakery/tests/test_client.py
@@ -3,27 +3,24 @@
 import base64
 import datetime
 import json
+import threading
 from unittest import TestCase
+
+import macaroonbakery as bakery
+import macaroonbakery.checkers as checkers
+import macaroonbakery.httpbakery as httpbakery
+import pymacaroons
+import requests
+from macaroonbakery import utils
+
+from httmock import HTTMock, urlmatch
+from six.moves.urllib.parse import parse_qs
+from six.moves.urllib.request import Request
+
 try:
     from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
 except ImportError:
     from http.server import HTTPServer, BaseHTTPRequestHandler
-import threading
-
-import pymacaroons
-
-from httmock import (
-    HTTMock,
-    urlmatch
-)
-import requests
-from six.moves.urllib.parse import parse_qs
-from six.moves.urllib.request import Request
-
-import macaroonbakery as bakery
-import macaroonbakery.httpbakery as httpbakery
-import macaroonbakery.checkers as checkers
-from macaroonbakery import utils
 
 AGES = datetime.datetime.utcnow() + datetime.timedelta(days=1)
 TEST_OP = bakery.Op(entity='test', action='test')

--- a/macaroonbakery/tests/test_codec.py
+++ b/macaroonbakery/tests/test_codec.py
@@ -3,12 +3,11 @@
 import base64
 from unittest import TestCase
 
+import macaroonbakery as bakery
+import macaroonbakery.checkers as checkers
 import nacl.public
 import six
-
-import macaroonbakery as bakery
 from macaroonbakery import codec
-import macaroonbakery.checkers as checkers
 
 
 class TestCodec(TestCase):

--- a/macaroonbakery/tests/test_discharge.py
+++ b/macaroonbakery/tests/test_discharge.py
@@ -2,11 +2,10 @@
 # Licensed under the LGPLv3, see LICENCE file for details.
 import unittest
 
-from pymacaroons import MACAROON_V1, Macaroon
-
 import macaroonbakery as bakery
 import macaroonbakery.checkers as checkers
 from macaroonbakery.tests import common
+from pymacaroons import MACAROON_V1, Macaroon
 
 
 class TestDischarge(unittest.TestCase):

--- a/macaroonbakery/tests/test_discharge_all.py
+++ b/macaroonbakery/tests/test_discharge_all.py
@@ -2,11 +2,10 @@
 # Licensed under the LGPLv3, see LICENCE file for details.
 import unittest
 
-from pymacaroons.verifier import Verifier
-
 import macaroonbakery as bakery
 import macaroonbakery.checkers as checkers
 from macaroonbakery.tests import common
+from pymacaroons.verifier import Verifier
 
 
 def always_ok(predicate):

--- a/macaroonbakery/tests/test_keyring.py
+++ b/macaroonbakery/tests/test_keyring.py
@@ -2,10 +2,10 @@
 # Licensed under the LGPLv3, see LICENCE file for details.
 import unittest
 
-from httmock import urlmatch, HTTMock
-
 import macaroonbakery as bakery
 import macaroonbakery.httpbakery as httpbakery
+
+from httmock import HTTMock, urlmatch
 
 
 class TestKeyRing(unittest.TestCase):

--- a/macaroonbakery/tests/test_macaroon.py
+++ b/macaroonbakery/tests/test_macaroon.py
@@ -3,13 +3,12 @@
 import json
 from unittest import TestCase
 
-import six
-import pymacaroons
-from pymacaroons import serializers
-
 import macaroonbakery as bakery
 import macaroonbakery.checkers as checkers
+import pymacaroons
+import six
 from macaroonbakery.tests import common
+from pymacaroons import serializers
 
 
 class TestMacaroon(TestCase):

--- a/macaroonbakery/tests/test_oven.py
+++ b/macaroonbakery/tests/test_oven.py
@@ -1,9 +1,8 @@
 # Copyright 2017 Canonical Ltd.
 # Licensed under the LGPLv3, see LICENCE file for details.
-from unittest import TestCase
-
 import copy
 from datetime import datetime, timedelta
+from unittest import TestCase
 
 import macaroonbakery as bakery
 

--- a/macaroonbakery/tests/test_time.py
+++ b/macaroonbakery/tests/test_time.py
@@ -1,14 +1,13 @@
 # Copyright 2017 Canonical Ltd.
 # Licensed under the LGPLv3, see LICENCE file for details.
+from collections import namedtuple
 from datetime import timedelta
 from unittest import TestCase
-from collections import namedtuple
-
-import pyrfc3339
-import pymacaroons
-from pymacaroons import Macaroon
 
 import macaroonbakery.checkers as checkers
+import pymacaroons
+import pyrfc3339
+from pymacaroons import Macaroon
 
 t1 = pyrfc3339.parse('2017-10-26T16:19:47.441402074Z', produce_naive=True)
 t2 = t1 + timedelta(hours=1)

--- a/macaroonbakery/tests/test_utils.py
+++ b/macaroonbakery/tests/test_utils.py
@@ -1,16 +1,15 @@
 # Copyright 2017 Canonical Ltd.
 # Licensed under the LGPLv3, see LICENCE file for details.
 
-from unittest import TestCase
-from datetime import datetime
-from pymacaroons.serializers import json_serializer
-
-import pytz
 import json
+from datetime import datetime
+from unittest import TestCase
 
 import macaroonbakery as bakery
-from macaroonbakery.utils import cookie
 import pymacaroons
+import pytz
+from macaroonbakery.utils import cookie
+from pymacaroons.serializers import json_serializer
 
 
 class CookieTest(TestCase):

--- a/macaroonbakery/utils.py
+++ b/macaroonbakery/utils.py
@@ -1,16 +1,17 @@
 # Copyright 2017 Canonical Ltd.
 # Licensed under the LGPLv3, see LICENCE file for details.
 import base64
-from datetime import datetime
 import binascii
 import json
 import webbrowser
-import six
-import six.moves.http_cookiejar as http_cookiejar
-from six.moves.urllib.parse import urlparse
+from datetime import datetime
 
+import six
 from pymacaroons import Macaroon
 from pymacaroons.serializers import json_serializer
+
+import six.moves.http_cookiejar as http_cookiejar
+from six.moves.urllib.parse import urlparse
 
 
 def to_bytes(s):


### PR DESCRIPTION
Also add an "isort" target to the Makefile so that we
don't forget the right isort flags.

Note that we exclude the auto-generated protobuf file.