### PR TITLE
Improve mock setup for 407-then-unknown test

### DIFF
--- a/macaroonbakery/tests/test_bakery.py
+++ b/macaroonbakery/tests/test_bakery.py
@@ -145,6 +145,16 @@ def discharge_401(url, request):
     }
 
 
+@urlmatch(path='.*/visit')
+def visit_200(url, request):
+    return {
+        'status_code': 200,
+        'content': {
+            'interactive': '/visit'
+        }
+    }
+
+
 @urlmatch(path='.*/wait')
 def wait_after_401(url, request):
     if request.url != 'http://example.com/wait':
@@ -239,7 +249,8 @@ class TestBakery(TestCase):
             def kind(self):
                 return 'unknown'
         client = httpbakery.Client(interaction_methods=[UnknownInteractor()])
-        with HTTMock(first_407_then_200), HTTMock(discharge_401):
+        with HTTMock(first_407_then_200), HTTMock(discharge_401),\
+                HTTMock(visit_200):
             with self.assertRaises(httpbakery.InteractionError) as exc:
                 requests.get(
                     ID_PATH,


### PR DESCRIPTION
`test_407_then_unknown_interaction_methods` causes the client to fetch
the possible methods supported by the discharger (because it's told that
it only supports a non-window method).  This is currently unmocked,
which causes the client to actually contact `http://example.com/visit`.
This fails in Launchpad builds because they run with a restrictive
network setup that doesn't even expose DNS lookups for non-permitted
hosts.

There isn't really a good way to simulate this without setting up a
similar stunt DNS server (though perhaps installing an
`httmock.all_requests` fallback mock that raises an exception would be a
good idea?), but this seems to be the only failure at the moment.