### PR TITLE
Fix handling of cookie with empty value

### DIFF
--- a/macaroonbakery/httpbakery/_client.py
+++ b/macaroonbakery/httpbakery/_client.py
@@ -320,8 +320,11 @@ def extract_macaroons(headers_or_request):
     mss = []
 
     def add_macaroon(data):
-        data = utils.b64decode(data)
-        data_as_objs = json.loads(data.decode('utf-8'))
+        try:
+            data = utils.b64decode(data)
+            data_as_objs = json.loads(data.decode('utf-8'))
+        except ValueError:
+            return
         ms = [utils.macaroon_from_dict(x) for x in data_as_objs]
         mss.append(ms)
 

--- a/macaroonbakery/tests/test_client.py
+++ b/macaroonbakery/tests/test_client.py
@@ -346,6 +346,11 @@ class TestClient(TestCase):
             value=encode_macaroon(m2),
             url='http://example.com',
         ))
+        jar.set_cookie(utils.cookie(
+            name='macaroon-empty',
+            value='',
+            url='http://example.com',
+        ))
         jar.add_cookie_header(req)
 
         macaroons = httpbakery.extract_macaroons(req)


### PR DESCRIPTION
Juju clears the value of macaroon cookies when they're invalidated which was causing the following:

```
Traceback (most recent call last):
  File "/home/johnsca/juju/py-macaroon-bakery/macaroonbakery/tests/test_client.py", line 356, in test_extract_macaroons_from_request
    macaroons = httpbakery.extract_macaroons(req)
  File "/home/johnsca/juju/py-macaroon-bakery/macaroonbakery/httpbakery/_client.py", line 337, in extract_macaroons
    add_macaroon(cs[c].value)
  File "/home/johnsca/juju/py-macaroon-bakery/macaroonbakery/httpbakery/_client.py", line 324, in add_macaroon
    data_as_objs = json.loads(data.decode('utf-8'))
  File "/usr/lib/python3.5/json/__init__.py", line 319, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.5/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.5/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```