### PR TITLE
Append .local to cookie domain when host is not an FQDN

### DIFF
--- a/macaroonbakery/_utils/__init__.py
+++ b/macaroonbakery/_utils/__init__.py
@@ -2,8 +2,8 @@
 # Licensed under the LGPLv3, see LICENCE file for details.
 import base64
 import binascii
+import ipaddress
 import json
-import re
 import webbrowser
 from datetime import datetime
 
@@ -13,9 +13,6 @@ from pymacaroons.serializers import json_serializer
 
 import six.moves.http_cookiejar as http_cookiejar
 from six.moves.urllib.parse import urlparse
-
-
-IPV4_RE = re.compile(r"\.\d+$", re.ASCII)
 
 
 def to_bytes(s):
@@ -139,9 +136,7 @@ def cookie(
     '''
     u = urlparse(url)
     domain = u.hostname
-    if '.' not in domain and not IPV4_RE.search(domain):
-        # If the host is not an FQDN, append a local doamin to make it a valid
-        # domain (this is what http.cookielib expects)
+    if '.' not in domain and not _is_ip_addr(domain):
         domain += ".local"
     port = str(u.port) if u.port is not None else None
     secure = u.scheme == 'https'
@@ -168,3 +163,11 @@ def cookie(
         rest=None,
         rfc2109=False,
     )
+
+
+def _is_ip_addr(h):
+    try:
+        ipaddress.ip_address(h)
+    except ValueError:
+        return False
+    return True

--- a/macaroonbakery/_utils/__init__.py
+++ b/macaroonbakery/_utils/__init__.py
@@ -3,6 +3,7 @@
 import base64
 import binascii
 import json
+import re
 import webbrowser
 from datetime import datetime
 
@@ -12,6 +13,9 @@ from pymacaroons.serializers import json_serializer
 
 import six.moves.http_cookiejar as http_cookiejar
 from six.moves.urllib.parse import urlparse
+
+
+IPV4_RE = re.compile(r"\.\d+$", re.ASCII)
 
 
 def to_bytes(s):
@@ -134,7 +138,11 @@ def cookie(
         it must be a naive timestamp in UTC.
     '''
     u = urlparse(url)
-    domain = u.hostname or u.netloc
+    domain = u.hostname
+    if '.' not in domain and not IPV4_RE.search(domain):
+        # If the host is not an FQDN, append a local doamin to make it a valid
+        # domain (this is what http.cookielib expects)
+        domain += ".local"
     port = str(u.port) if u.port is not None else None
     secure = u.scheme == 'https'
     if expires is not None:

--- a/macaroonbakery/httpbakery/_client.py
+++ b/macaroonbakery/httpbakery/_client.py
@@ -290,12 +290,8 @@ def _prepare_discharge_hook(req, client):
                 Retry.count)
             )
         client.handle_error(error, req.url)
-        # Replace the private _cookies from req as it is a copy of
-        # the original cookie jar passed into the requests method and we need
-        # to set the cookie for this request.
-        req._cookies = client.cookies
         req.headers.pop('Cookie', None)
-        req.prepare_cookies(req._cookies)
+        req.prepare_cookies(client.cookies)
         req.headers[BAKERY_PROTOCOL_HEADER] = \
             str(bakery.LATEST_VERSION)
         with requests.Session() as s:

--- a/macaroonbakery/tests/test_client.py
+++ b/macaroonbakery/tests/test_client.py
@@ -56,6 +56,9 @@ class TestClient(TestCase):
             httpd.shutdown()
 
     def test_cookie_domain_host_not_fqdn(self):
+        # See
+        # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/53
+
         b = new_bakery('loc', None, None)
 
         def handler(*args):
@@ -69,6 +72,9 @@ class TestClient(TestCase):
                 caveats=None, ops=[TEST_OP])
             self.assertEquals(srv_macaroon.macaroon.location, 'loc')
             client = httpbakery.Client()
+            # Note: by using "localhost" instead of the presumably numeric address held
+            # in httpd.server_address, we're triggering the no-FQDN logic in the cookie
+            # code.
             resp = requests.get(
                 url='http://localhost:' + str(httpd.server_address[1]),
                 cookies=client.cookies, auth=client.auth())

--- a/macaroonbakery/tests/test_utils.py
+++ b/macaroonbakery/tests/test_utils.py
@@ -30,9 +30,18 @@ class CookieTest(TestCase):
         c = cookie('http://myhost', 'test', 'value')
         self.assertEqual(c.domain, 'myhost.local')
 
-    def test_cookie_with_hostname_ipc4(self):
+    def test_cookie_with_hostname_ipv4(self):
         c = cookie('http://1.2.3.4', 'test', 'value')
         self.assertEqual(c.domain, '1.2.3.4')
+
+    def test_cookie_with_hostname_ipv6(self):
+        c = cookie('http://[dead::beef]', 'test', 'value')
+        self.assertEqual(c.domain, 'dead::beef')
+
+    def test_cookie_with_hostname_like_ipv4(self):
+        c = cookie('http://1.2.3.4.com', 'test', 'value')
+        self.assertEqual(c.domain, '1.2.3.4.com')
+
 
 class TestB64Decode(TestCase):
     def test_decode(self):

--- a/macaroonbakery/tests/test_utils.py
+++ b/macaroonbakery/tests/test_utils.py
@@ -26,6 +26,13 @@ class CookieTest(TestCase):
             ValueError, cookie, 'http://example.com', 'test', 'value',
             expires=timestamp)
 
+    def test_cookie_with_hostname_not_fqdn(self):
+        c = cookie('http://myhost', 'test', 'value')
+        self.assertEqual(c.domain, 'myhost.local')
+
+    def test_cookie_with_hostname_ipc4(self):
+        c = cookie('http://1.2.3.4', 'test', 'value')
+        self.assertEqual(c.domain, '1.2.3.4')
 
 class TestB64Decode(TestCase):
     def test_decode(self):

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 # Copyright 2017 Canonical Ltd.
 # Licensed under the LGPLv3, see LICENCE file for details.
+import sys
 import platform
 
 from setuptools import (
@@ -46,6 +47,9 @@ if len(distribution) == 3 and distribution[2] == 'trusty':
         'pyasn1==0.1.9',
         'ndg_httpsclient==0.3.3',
     ])
+
+if sys.version_info.major == 2:
+    requirements.append('ipaddress')
 
 
 setup(


### PR DESCRIPTION
When the request URL is not an FQDN (nor an IPv4 address), domain for cookies should have `.local` appended, otherwise they're not presented in subsequent requests.
 
Fixes #53 