### PR TITLE
fix issues in exceptional cases

### DIFF
--- a/macaroonbakery/tests/test_httpbakery.py
+++ b/macaroonbakery/tests/test_httpbakery.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
-from macaroonbakery.httpbakery import WebBrowserInteractionInfo
+import macaroonbakery.httpbakery as httpbakery
+import macaroonbakery.bakery as bakery
 
 
 class TestWebBrowserInteractionInfo(TestCase):
@@ -9,8 +10,35 @@ class TestWebBrowserInteractionInfo(TestCase):
         info_dict = {
             'VisitURL': 'https://example.com/visit',
             'WaitTokenURL': 'https://example.com/wait'}
-        interaction_info = WebBrowserInteractionInfo.from_dict(info_dict)
+        interaction_info = httpbakery.WebBrowserInteractionInfo.from_dict(info_dict)
         self.assertEqual(
             interaction_info.visit_url, 'https://example.com/visit')
         self.assertEqual(
             interaction_info.wait_token_url, 'https://example.com/wait')
+
+
+class TestError(TestCase):
+
+    def test_from_dict_upper_case_fields(self):
+        err = httpbakery.Error.from_dict({
+            'Message': 'm',
+            'Code': 'c',
+        })
+        self.assertEqual(err, httpbakery.Error(
+            code='c',
+            message='m',
+            info=None,
+            version=bakery.LATEST_VERSION,
+        ))
+
+    def test_from_dict_lower_case_fields(self):
+        err = httpbakery.Error.from_dict({
+            'message': 'm',
+            'code': 'c',
+        })
+        self.assertEqual(err, httpbakery.Error(
+            code='c',
+            message='m',
+            info=None,
+            version=bakery.LATEST_VERSION,
+        ))


### PR DESCRIPTION
The Candid server produces errors with lower case "message" and
"code" fields, but py-macaroon-bakery doesn't recognise those fields,
which can obscure errors.

Also, pymacaroons can raise an open-ended set of possible
exceptions when verifying macaroons. Rather than try to enumerate
them all, catch all exceptions and turn them into VerificationError.
This means that we don't raise AuthInitError when macaroons fail
verification (something that should only happen if an internal error
happens).