### PR TITLE
Mapping import deprecation fix

### DIFF
--- a/macaroonbakery/checkers/_auth_context.py
+++ b/macaroonbakery/checkers/_auth_context.py
@@ -1,9 +1,12 @@
 # Copyright 2017 Canonical Ltd.
 # Licensed under the LGPLv3, see LICENCE file for details.
-import collections
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 
-class AuthContext(collections.Mapping):
+class AuthContext(Mapping):
     ''' Holds a set of keys and values relevant to authorization.
 
     It is passed as an argument to authorization checkers, so that the checkers


### PR DESCRIPTION
When running pytest on our project [Lighter](https://gitlab.com/inbitcoin/lighter), which is using this library, with python 3.7 on Debian Buster we receive this warning:
```
/path/to/env/lib/python3.7/site-packages/macaroonbakery/checkers/_auth_context.py:6
  /path/to/env/lib/python3.7/site-packages/macaroonbakery/checkers/_auth_context.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working      
    class AuthContext(collections.Mapping):
```

As stated [here](https://docs.python.org/3.7/library/collections.html):
> Deprecated since version 3.3, will be removed in version 3.9: Moved Collections Abstract Base Classes to the collections.abc module. For backwards compatibility, they continue to be visible in this module through Python 3.8.
collections.Mapping has been moved to collections.abc.Mapping, hence we're proposing a code change that should not break backwards compatibility.