### PR TITLE
Fix tests on Python 3.12

### DIFF
--- a/macaroonbakery/tests/test_client.py
+++ b/macaroonbakery/tests/test_client.py
@@ -51,7 +51,7 @@ class TestClient(TestWithFixtures):
             srv_macaroon = b.oven.macaroon(
                 version=bakery.LATEST_VERSION, expiry=AGES,
                 caveats=None, ops=[TEST_OP])
-            self.assertEquals(srv_macaroon.macaroon.location, 'loc')
+            self.assertEqual(srv_macaroon.macaroon.location, 'loc')
             client = httpbakery.Client()
             client.cookies.set_cookie(requests.cookies.create_cookie(
                 'macaroon-test', base64.b64encode(json.dumps([
@@ -63,7 +63,7 @@ class TestClient(TestWithFixtures):
                     str(httpd.server_address[1]),
                 cookies=client.cookies, auth=client.auth())
             resp.raise_for_status()
-            self.assertEquals(resp.text, 'done')
+            self.assertEqual(resp.text, 'done')
         finally:
             httpd.shutdown()
 
@@ -110,7 +110,7 @@ class TestClient(TestWithFixtures):
                     cookies=client.cookies,
                     auth=client.auth())
             resp.raise_for_status()
-            self.assertEquals(resp.text, 'done')
+            self.assertEqual(resp.text, 'done')
         finally:
             httpd.shutdown()
 
@@ -157,7 +157,7 @@ class TestClient(TestWithFixtures):
                     cookies=client.cookies,
                     auth=client.auth())
             resp.raise_for_status()
-            self.assertEquals(resp.text, 'done')
+            self.assertEqual(resp.text, 'done')
         finally:
             httpd.shutdown()
 
@@ -203,7 +203,7 @@ class TestClient(TestWithFixtures):
                     cookies=client.cookies,
                     auth=client.auth())
             resp.raise_for_status()
-            self.assertEquals(resp.text, 'done')
+            self.assertEqual(resp.text, 'done')
         finally:
             httpd.shutdown()
 
@@ -222,7 +222,7 @@ class TestClient(TestWithFixtures):
             srv_macaroon = b.oven.macaroon(
                 version=bakery.LATEST_VERSION, expiry=AGES,
                 caveats=None, ops=[TEST_OP])
-            self.assertEquals(srv_macaroon.macaroon.location, 'loc')
+            self.assertEqual(srv_macaroon.macaroon.location, 'loc')
             client = httpbakery.Client()
             # Note: by using "localhost" instead of the presumably numeric address held
             # in httpd.server_address, we're triggering the no-FQDN logic in the cookie
@@ -231,7 +231,7 @@ class TestClient(TestWithFixtures):
                 url='http://localhost:' + str(httpd.server_address[1]),
                 cookies=client.cookies, auth=client.auth())
             resp.raise_for_status()
-            self.assertEquals(resp.text, 'done')
+            self.assertEqual(resp.text, 'done')
         except httpbakery.BakeryException:
             pass  # interacion required exception is expected
         finally:
@@ -254,7 +254,7 @@ class TestClient(TestWithFixtures):
             srv_macaroon = b.oven.macaroon(
                 version=bakery.LATEST_VERSION,
                 expiry=AGES, caveats=None, ops=[TEST_OP])
-            self.assertEquals(srv_macaroon.macaroon.location, 'loc')
+            self.assertEqual(srv_macaroon.macaroon.location, 'loc')
             headers = {
                 'Macaroons': base64.b64encode(json.dumps([
                     srv_macaroon.to_dict().get('m')
@@ -265,7 +265,7 @@ class TestClient(TestWithFixtures):
                     str(httpd.server_address[1]),
                 headers=headers)
             resp.raise_for_status()
-            self.assertEquals(resp.text, 'done')
+            self.assertEqual(resp.text, 'done')
         finally:
             httpd.shutdown()
 
@@ -317,8 +317,8 @@ class TestClient(TestWithFixtures):
                 base64.b64decode(client.cookies.get('macaroon-test')).decode('utf-8'))[0])
             t = checkers.macaroons_expiry_time(
                 checkers.Namespace(), [m.macaroon])
-            self.assertEquals(ages, t)
-            self.assertEquals(resp.text, 'done')
+            self.assertEqual(ages, t)
+            self.assertEqual(resp.text, 'done')
         finally:
             httpd.shutdown()
 
@@ -557,13 +557,13 @@ class TestClient(TestWithFixtures):
                         cookies=client.cookies,
                         auth=client.auth())
                 if platform.python_version_tuple()[0] == '2':
-                    self.assertEquals(str(discharge_error.exception),
-                                      'third party refused dischargex: unexpected response: '
-                                      "[503] 'bad system'")
+                    self.assertEqual(str(discharge_error.exception),
+                                     'third party refused dischargex: unexpected response: '
+                                     "[503] 'bad system'")
                 else:
-                    self.assertEquals(str(discharge_error.exception),
-                                      'third party refused dischargex: unexpected response: '
-                                      "[503] b'bad system'")
+                    self.assertEqual(str(discharge_error.exception),
+                                     'third party refused dischargex: unexpected response: '
+                                     "[503] b'bad system'")
 
         finally:
             httpd.shutdown()
@@ -591,10 +591,10 @@ class TestClient(TestWithFixtures):
         jar.add_cookie_header(req)
 
         macaroons = httpbakery.extract_macaroons(req)
-        self.assertEquals(len(macaroons), 2)
+        self.assertEqual(len(macaroons), 2)
         macaroons.sort(key=lambda ms: ms[0].identifier)
-        self.assertEquals(macaroons[0][0].identifier, m1.identifier)
-        self.assertEquals(macaroons[1][0].identifier, m2.identifier)
+        self.assertEqual(macaroons[0][0].identifier, m1.identifier)
+        self.assertEqual(macaroons[1][0].identifier, m2.identifier)
 
     def test_handle_error_cookie_path(self):
         macaroon = bakery.Macaroon(

--- a/macaroonbakery/tests/test_codec.py
+++ b/macaroonbakery/tests/test_codec.py
@@ -26,7 +26,7 @@ class TestCodec(TestCase):
             self.fp_key,
             None)
         res = bakery.decode_caveat(self.tp_key, cid)
-        self.assertEquals(res, bakery.ThirdPartyCaveatInfo(
+        self.assertEqual(res, bakery.ThirdPartyCaveatInfo(
             first_party_public_key=self.fp_key.public_key,
             root_key=b'a random string',
             condition='is-authenticated-user',
@@ -48,7 +48,7 @@ class TestCodec(TestCase):
             self.fp_key,
             None)
         res = bakery.decode_caveat(self.tp_key, cid)
-        self.assertEquals(res, bakery.ThirdPartyCaveatInfo(
+        self.assertEqual(res, bakery.ThirdPartyCaveatInfo(
             first_party_public_key=self.fp_key.public_key,
             root_key=b'a random string',
             condition='is-authenticated-user',
@@ -72,7 +72,7 @@ class TestCodec(TestCase):
             self.fp_key,
             ns)
         res = bakery.decode_caveat(self.tp_key, cid)
-        self.assertEquals(res, bakery.ThirdPartyCaveatInfo(
+        self.assertEqual(res, bakery.ThirdPartyCaveatInfo(
             first_party_public_key=self.fp_key.public_key,
             root_key=b'a random string',
             condition='is-authenticated-user',
@@ -110,7 +110,7 @@ class TestCodec(TestCase):
             '0V2lEOHhRUWdjU3ljOHY4eUt4dEhxejVEczJOYmh1ZDJhUFdt'
             'UTVMcVlNWitmZ2FNaTAxdE9DIn0=')
         cav = bakery.decode_caveat(tp_key, encrypted_cav)
-        self.assertEquals(cav, bakery.ThirdPartyCaveatInfo(
+        self.assertEqual(cav, bakery.ThirdPartyCaveatInfo(
             condition='caveat condition',
             first_party_public_key=fp_key.public_key,
             third_party_key_pair=tp_key,
@@ -164,7 +164,7 @@ class TestCodec(TestCase):
             '1LX4VKxymqG62UGPo78wOv0_fKjr3OI6PPJOYOQgBMclemlRF2',
         )
         cav = bakery.decode_caveat(tp_key, encrypted_cav)
-        self.assertEquals(cav, bakery.ThirdPartyCaveatInfo(
+        self.assertEqual(cav, bakery.ThirdPartyCaveatInfo(
             condition='third party condition',
             first_party_public_key=fp_key.public_key,
             third_party_key_pair=tp_key,
@@ -190,7 +190,7 @@ class TestCodec(TestCase):
             bakery.encode_uvarint(test[0], data)
             for v in test[1]:
                 expected.append(v)
-            self.assertEquals(data, expected)
+            self.assertEqual(data, expected)
             val = codec.decode_uvarint(bytes(data))
-            self.assertEquals(test[0], val[0])
-            self.assertEquals(len(test[1]), val[1])
+            self.assertEqual(test[0], val[0])
+            self.assertEqual(len(test[1]), val[1])

--- a/macaroonbakery/tests/test_macaroon.py
+++ b/macaroonbakery/tests/test_macaroon.py
@@ -19,17 +19,17 @@ class TestMacaroon(TestCase):
             'here',
             bakery.LATEST_VERSION)
         self.assertIsNotNone(m)
-        self.assertEquals(m._macaroon.identifier, b'some id')
-        self.assertEquals(m._macaroon.location, 'here')
-        self.assertEquals(m.version, bakery.LATEST_VERSION)
+        self.assertEqual(m._macaroon.identifier, b'some id')
+        self.assertEqual(m._macaroon.location, 'here')
+        self.assertEqual(m.version, bakery.LATEST_VERSION)
 
     def test_add_first_party_caveat(self):
         m = bakery.Macaroon('rootkey', 'some id', 'here',
                             bakery.LATEST_VERSION)
         m.add_caveat(checkers.Caveat('test_condition'))
         caveats = m.first_party_caveats()
-        self.assertEquals(len(caveats), 1)
-        self.assertEquals(caveats[0].caveat_id, b'test_condition')
+        self.assertEqual(len(caveats), 1)
+        self.assertEqual(caveats[0].caveat_id, b'test_condition')
 
     def test_add_third_party_caveat(self):
         locator = bakery.ThirdPartyStore()

--- a/macaroonbakery/tests/test_namespace.py
+++ b/macaroonbakery/tests/test_namespace.py
@@ -24,12 +24,12 @@ class TestNamespace(TestCase):
         for test in tests:
             ns = checkers.Namespace(test[1])
             data = ns.serialize_text()
-            self.assertEquals(data, test[2])
-            self.assertEquals(str(ns), test[2].decode('utf-8'))
+            self.assertEqual(data, test[2])
+            self.assertEqual(str(ns), test[2].decode('utf-8'))
 
         # Check that it can be deserialize to the same thing:
         ns1 = checkers.deserialize_namespace(data)
-        self.assertEquals(ns1, ns)
+        self.assertEqual(ns1, ns)
 
     # TODO(rogpeppe) add resolve tests
 
@@ -37,16 +37,16 @@ class TestNamespace(TestCase):
         ns = checkers.Namespace(None)
         ns.register('testns', 't')
         prefix = ns.resolve('testns')
-        self.assertEquals(prefix, 't')
+        self.assertEqual(prefix, 't')
 
         ns.register('other', 'o')
         prefix = ns.resolve('other')
-        self.assertEquals(prefix, 'o')
+        self.assertEqual(prefix, 'o')
 
         # If we re-register the same URL, it does nothing.
         ns.register('other', 'p')
         prefix = ns.resolve('other')
-        self.assertEquals(prefix, 'o')
+        self.assertEqual(prefix, 'o')
 
     def test_register_bad_uri(self):
         ns = checkers.Namespace(None)

--- a/macaroonbakery/tests/test_oven.py
+++ b/macaroonbakery/tests/test_oven.py
@@ -45,9 +45,9 @@ class TestOven(TestCase):
         for about, ops, expected in canonical_ops_tests:
             new_ops = copy.copy(ops)
             canonical_ops = bakery.canonical_ops(new_ops)
-            self.assertEquals(canonical_ops, expected)
+            self.assertEqual(canonical_ops, expected)
             # Verify that the original array isn't changed.
-            self.assertEquals(new_ops, ops)
+            self.assertEqual(new_ops, ops)
 
     def test_multiple_ops(self):
         test_oven = bakery.Oven(
@@ -58,8 +58,8 @@ class TestOven(TestCase):
         m = test_oven.macaroon(bakery.LATEST_VERSION, AGES,
                                None, ops)
         got_ops, conds = test_oven.macaroon_ops([m.macaroon])
-        self.assertEquals(len(conds), 1)  # time-before caveat.
-        self.assertEquals(bakery.canonical_ops(got_ops), ops)
+        self.assertEqual(len(conds), 1)  # time-before caveat.
+        self.assertEqual(bakery.canonical_ops(got_ops), ops)
 
     def test_multiple_ops_in_id(self):
         test_oven = bakery.Oven()
@@ -69,8 +69,8 @@ class TestOven(TestCase):
         m = test_oven.macaroon(bakery.LATEST_VERSION, AGES,
                                None, ops)
         got_ops, conds = test_oven.macaroon_ops([m.macaroon])
-        self.assertEquals(len(conds), 1)  # time-before caveat.
-        self.assertEquals(bakery.canonical_ops(got_ops), ops)
+        self.assertEqual(len(conds), 1)  # time-before caveat.
+        self.assertEqual(bakery.canonical_ops(got_ops), ops)
 
     def test_multiple_ops_in_id_with_version1(self):
         test_oven = bakery.Oven()
@@ -79,8 +79,8 @@ class TestOven(TestCase):
                bakery.Op('two', 'read')]
         m = test_oven.macaroon(bakery.VERSION_1, AGES, None, ops)
         got_ops, conds = test_oven.macaroon_ops([m.macaroon])
-        self.assertEquals(len(conds), 1)  # time-before caveat.
-        self.assertEquals(bakery.canonical_ops(got_ops), ops)
+        self.assertEqual(len(conds), 1)  # time-before caveat.
+        self.assertEqual(bakery.canonical_ops(got_ops), ops)
 
     def test_huge_number_of_ops_gives_small_macaroon(self):
         test_oven = bakery.Oven(
@@ -93,9 +93,9 @@ class TestOven(TestCase):
         m = test_oven.macaroon(bakery.LATEST_VERSION, AGES,
                                None, ops)
         got_ops, conds = test_oven.macaroon_ops([m.macaroon])
-        self.assertEquals(len(conds), 1)  # time-before caveat.
-        self.assertEquals(bakery.canonical_ops(got_ops),
-                          bakery.canonical_ops(ops))
+        self.assertEqual(len(conds), 1)  # time-before caveat.
+        self.assertEqual(bakery.canonical_ops(got_ops),
+                         bakery.canonical_ops(ops))
 
         data = m.serialize_json()
         self.assertLess(len(data), 300)
@@ -111,8 +111,8 @@ class TestOven(TestCase):
         m = test_oven.macaroon(bakery.LATEST_VERSION, AGES,
                                None, ops)
         got_ops, conds = test_oven.macaroon_ops([m.macaroon])
-        self.assertEquals(bakery.canonical_ops(got_ops),
-                          bakery.canonical_ops(ops))
+        self.assertEqual(bakery.canonical_ops(got_ops),
+                         bakery.canonical_ops(ops))
 
         # Make another macaroon containing the same ops in a different order.
         ops = [bakery.Op('one', 'write'),
@@ -121,4 +121,4 @@ class TestOven(TestCase):
                bakery.Op('two', 'read')]
         test_oven.macaroon(bakery.LATEST_VERSION, AGES, None,
                            ops)
-        self.assertEquals(len(st._store), 1)
+        self.assertEqual(len(st._store), 1)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,6 +11,7 @@ mock==1.0.1
 nose2==0.13.0
 pbr==3.1.1
 python-mimeparse==1.6.0
-testtools==2.3.0
+testtools==2.3.0; python_version<"3"
+testtools==2.5.0; python_version>="3"
 traceback2==1.4.0
-unittest2==1.1.0
+unittest2==1.1.0; python_version<"3"


### PR DESCRIPTION
In practice something like #95 will also be needed to make the test suite pass on modern systems.  I worked around that for testing by setting `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python`.