### PR TITLE
build: make most Makefile targets work on noble

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -64,7 +64,7 @@ development.
 
 3. Prepare your development environment::
 
-    $ make devenv
+    $ make setup
 
 4. Create a branch for local development::
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,8 @@
-# Copyright 2017 Canonical Ltd.
+# Copyright 2017,2024 Canonical Ltd.
 # Licensed under the LGPLv3, see LICENCE file for details.
 include sysdeps.mk
 
 PYTHON = python
-# Since the python-tox package in Ubuntu uses Python 3, use pip to install tox
-# instead. This also works on OSX where tox is not present in Homebrew.
-PIP_SYSDEPS = tox
-
-PIP = sudo pip install $(1)
 
 SYSDEPS_INSTALLED = .sysdeps-installed
 DEVENV = venv
@@ -28,7 +23,6 @@ else
 	@echo 'Debian packages:'
 	@echo '$(APT_SYSDEPS).'
 endif
-	sudo pip3 install $(PIP_SYSDEPS)
 	touch $(SYSDEPS_INSTALLED)
 
 

--- a/sysdeps.mk
+++ b/sysdeps.mk
@@ -1,1 +1,1 @@
-APT_SYSDEPS = python3-pip python3-setuptools libsodium-dev libffi-dev libssl-dev
+APT_SYSDEPS = python3-pip python3-setuptools libsodium-dev libffi-dev libssl-dev tox isort

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-# Copyright 2017 Canonical Ltd.
+# Copyright 2017,2024 Canonical Ltd.
 # Licensed under the LGPLv3, see LICENCE file for details.
 
 coverage==7.3.2
@@ -11,6 +11,7 @@ mock==1.0.1
 nose2==0.13.0
 pbr==3.1.1
 python-mimeparse==1.6.0
+setuptools==75.1.0
 testtools==2.3.0; python_version<"3"
 testtools==2.5.0; python_version>="3"
 traceback2==1.4.0


### PR DESCRIPTION
This updates the Makefile and apt dependencies to work on Ubuntu 24.04.

`make lint` still doesn't work, but I'll do that in a separate PR.