### PR TITLE
fix: create cookies that work with MozillaCookieJar

### DIFF
--- a/macaroonbakery/_utils/__init__.py
+++ b/macaroonbakery/_utils/__init__.py
@@ -160,7 +160,7 @@ def cookie(
         discard=False,
         comment=None,
         comment_url=None,
-        rest=None,
+        rest={},
         rfc2109=False,
     )
 

--- a/macaroonbakery/tests/test_utils.py
+++ b/macaroonbakery/tests/test_utils.py
@@ -3,8 +3,10 @@
 # Copyright 2017 Canonical Ltd.
 # Licensed under the LGPLv3, see LICENCE file for details.
 
+from http import cookiejar
 import json
 from datetime import datetime
+import tempfile
 from unittest import TestCase
 
 import macaroonbakery.bakery as bakery
@@ -47,6 +49,18 @@ class CookieTest(TestCase):
     def test_cookie_with_hostname_not_ascii(self):
         c = cookie('http://κουλουράκι', 'test', 'value')
         self.assertEqual(c.domain, 'κουλουράκι.local')
+
+
+    def test_mozilla_cookie_jar(self):
+        # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/88
+        with tempfile.TemporaryDirectory() as cookie_dir:
+            c = cookie('http://κουλουράκι', 'test', 'value')
+            jar = cookiejar.MozillaCookieJar(cookie_dir + "/cookie_jar")
+
+            jar.set_cookie(c)
+
+            jar.save()
+
 
 
 class TestB64Decode(TestCase):


### PR DESCRIPTION
Fixes #88 